### PR TITLE
Fixed problem in truth mapping, updated default indices to reflect OD veto decision

### DIFF
--- a/config/data/iwcd_short.yaml
+++ b/config/data/iwcd_short.yaml
@@ -1,4 +1,4 @@
 # @package _group_
-split_path: /fast_scratch/WatChMaL/data/IWCD_mPMT_Short_3M_OD_veto_idxs.npz
+split_path: /fast_scratch/WatChMaL/data/IWCD_mPMT_Short_3M_idxs.npz
 dataset:
   h5file: /fast_scratch/WatChMaL/data/IWCD_mPMT_Short_emg_E0to1000MeV_digihits.h5

--- a/config/data/iwcd_short.yaml
+++ b/config/data/iwcd_short.yaml
@@ -1,4 +1,4 @@
 # @package _group_
-split_path: /fast_scratch/WatChMaL/data/IWCD_mPMT_Short_3M_idxs.npz
+split_path: /fast_scratch/WatChMaL/data/IWCD_mPMT_Short_3M_full_train_OD_veto_test_idxs.npz
 dataset:
   h5file: /fast_scratch/WatChMaL/data/IWCD_mPMT_Short_emg_E0to1000MeV_digihits.h5

--- a/config/resnet_test.yaml
+++ b/config/resnet_test.yaml
@@ -4,8 +4,8 @@ gpu_list:
 seed: null
 dump_path: './outputs/'
 defaults:
-    - data: iwcd_postveto_nomichel
-    - data/dataset: iwcd_cnn
+    - data: iwcd_short
+    - data/dataset: iwcd_cnn_short
     - model: classifier
     - model/feature_extractor: resnet18
     - model/classification_network: resnet_fc

--- a/watchmal/dataset/DigiTruthMapping.py
+++ b/watchmal/dataset/DigiTruthMapping.py
@@ -46,6 +46,7 @@ class DigiTruthMapping:
         dtkeys=[]
         dtvals=[]
         start_time = time.time()
+        j=0
         for i in range(len(dtfiles) ):
             if i%100000==0 and i!=0:
                 cur_time = time.time()
@@ -55,13 +56,15 @@ class DigiTruthMapping:
                 print_time( elapsed_time,   "  time elapsed   =" )
                 print_time( remaining_time, "  remaining time =" )
                                    
-            for j in range( i, len(mcfiles)):
+            for j in range( j, len(mcfiles)):
                 #if mcfiles[j] == dtfiles[i] and mcids[j] == dtids[i]:
                 if mcids[j] == dtids[i]:
                     mckeys.append(i)
                     mcvals.append(j)
                     dtkeys.append(j)
                     dtvals.append(i)
+                    # verify matching root files
+                    assert(dtfiles[i] == mcfiles[j])
                     break
         self.data_for_truth = dict( zip(dtkeys,dtvals) )
         self.truth_for_data = dict( zip(mckeys,mcvals))        


### PR DESCRIPTION
Modified class DigiTruthMapping to search for next truth event from the last truth event, rather than the digihit index. Updated default indices to use full indices for training, and OD vetoed indices for testing.
