### PR TITLE
Make loss computation optional in evaluation, allowing extra classes

### DIFF
--- a/config/tasks/evaluate/test.yaml
+++ b/config/tasks/evaluate/test.yaml
@@ -1,4 +1,5 @@
 # @package _group_
+report_test_metrics: false
 data_loaders:
   test:
     split_key: test_idxs

--- a/watchmal/dataset/data_utils.py
+++ b/watchmal/dataset/data_utils.py
@@ -53,7 +53,7 @@ def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, s
         sampler = DistributedSamplerWrapper(sampler=sampler, seed=seed)
     
     # TODO: added drop_last, should decide if we want to keep this
-    return DataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=num_workers, drop_last=True)
+    return DataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=num_workers, drop_last=False)
 
 
 def get_transformations(transformations, transform_names):


### PR DESCRIPTION
Modifies forward and evaluate() to make computation of loss and accuracy optional, allowing model to be evaluated on data with labels outside range of loss criterion