### PR TITLE
Allow compatibility with both SK and HK

### DIFF
--- a/config/data/dataset/SK_cnn.yaml
+++ b/config/data/dataset/SK_cnn.yaml
@@ -4,3 +4,4 @@ pmt_positions_file: /home/ayankelevich/WatChMaL/SK_PMT_image_positions.npz
 collapse_arrays: False
 use_times: True
 use_charges: True
+one_indexed: True

--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -14,7 +14,7 @@ from watchmal.dataset.h5_dataset import H5Dataset
 import watchmal.dataset.data_utils as du
 
 class CNNDataset(H5Dataset):
-    def __init__(self, h5file, pmt_positions_file, is_distributed, use_times=True, use_charges=True, transforms=None, collapse_arrays=False):
+    def __init__(self, h5file, pmt_positions_file, is_distributed, use_times=True, use_charges=True, transforms=None, collapse_arrays=False, one_indexed=False):
         """
         Args:
             h5_path             ... path to h5 dataset file
@@ -55,7 +55,8 @@ class CNNDataset(H5Dataset):
         Returns:
             data                    ... array of hits in cnn format
         """
-        hit_pmts = hit_pmts-1 #SK cable numbers start at 1
+        if one_indexed:
+            hit_pmts = hit_pmts-1 #SK cable numbers start at 1
 
         hit_rows = self.pmt_positions[hit_pmts, 0]
         hit_cols = self.pmt_positions[hit_pmts, 1]

--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -32,6 +32,7 @@ class CNNDataset(H5Dataset):
                             np.count_nonzero(self.pmt_positions[:,0] == row) == self.data_size[1]]
         self.collapse_arrays = collapse_arrays
         self.transforms = None #du.get_transformations(transformations, transforms)
+        self.one_indexed = one_indexed
 
         n_channels = 0
         if use_times:
@@ -55,7 +56,7 @@ class CNNDataset(H5Dataset):
         Returns:
             data                    ... array of hits in cnn format
         """
-        if one_indexed:
+        if self.one_indexed:
             hit_pmts = hit_pmts-1 #SK cable numbers start at 1
 
         hit_rows = self.pmt_positions[hit_pmts, 0]


### PR DESCRIPTION
Data from the SKDETSIM-based pipeline has PMT IDs starting at 1, while data from our WCSim simulation based pipeline has PMT IDs starting at 0. So for SK, we need to subtract one from the PMT ID to get the appropriate index of the arrays in the PMT positions mapping, since numpy arrays are 0-indexed.

Previously the CNN dataset had been set up by @ayankele to subtract 1 from PMT IDs for SK. With this change, it becomes optional, so we can also use WCSim data with this same dataset class.

To set this option, the config file for the dataset should have: `one_indexed: True`