### PR TITLE
Add ability to map labels to range 0 to N

### DIFF
--- a/config/engine/classifier.yaml
+++ b/config/engine/classifier.yaml
@@ -1,1 +1,4 @@
 _target_: watchmal.engine.engine_classifier.ClassifierEngine
+label_set:
+  - 0
+  - 1

--- a/config/model/classification_network/resnet.yaml
+++ b/config/model/classification_network/resnet.yaml
@@ -1,1 +1,3 @@
 _target_: watchmal.model.classifier.PassThrough
+num_inputs: 2
+num_classes: 2

--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -14,7 +14,7 @@ from watchmal.dataset.h5_dataset import H5Dataset
 import watchmal.dataset.data_utils as du
 
 class CNNDataset(H5Dataset):
-    def __init__(self, h5file, pmt_positions_file, is_distributed, use_times=True, use_charges=True, transforms=None, collapse_arrays=False):
+    def __init__(self, h5file, pmt_positions_file, is_distributed, use_times=True, use_charges=True, transforms=None, collapse_arrays=False, label_set=None):
         """
         Args:
             h5_path             ... path to h5 dataset file
@@ -22,7 +22,7 @@ class CNNDataset(H5Dataset):
             transforms          ... transforms to apply
             collapse_arrays     ... whether to collapse arrays in return
         """
-        super().__init__(h5file, is_distributed)
+        super().__init__(h5file, is_distributed, label_set=label_set)
         
         self.pmt_positions = np.load(pmt_positions_file)['pmt_image_positions']
         self.use_times = use_times

--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -14,7 +14,7 @@ from watchmal.dataset.h5_dataset import H5Dataset
 import watchmal.dataset.data_utils as du
 
 class CNNDataset(H5Dataset):
-    def __init__(self, h5file, pmt_positions_file, is_distributed, use_times=True, use_charges=True, transforms=None, collapse_arrays=False, label_set=None):
+    def __init__(self, h5file, pmt_positions_file, is_distributed, use_times=True, use_charges=True, transforms=None, collapse_arrays=False):
         """
         Args:
             h5_path             ... path to h5 dataset file
@@ -22,7 +22,7 @@ class CNNDataset(H5Dataset):
             transforms          ... transforms to apply
             collapse_arrays     ... whether to collapse arrays in return
         """
-        super().__init__(h5file, is_distributed, label_set=label_set)
+        super().__init__(h5file, is_distributed)
         
         self.pmt_positions = np.load(pmt_positions_file)['pmt_image_positions']
         self.use_times = use_times

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -46,16 +46,12 @@ class H5CommonDataset(Dataset, ABC):
             self.initialize()
 
     def initialize(self):
-        # Set attribute so that method won't be invoked again
-        self.initialized = True
 
         self.h5_file = h5py.File(self.h5_path, "r")
 
 #        self.event_ids  = np.array(self.h5_file["event_ids"])
 #        self.root_files = np.array(self.h5_file["root_files"])
         self.labels = np.array(self.h5_file["labels"])
-        if self.label_set is not None:
-            self.map_labels(self.label_set)
 
 #        self.positions  = np.array(self.h5_file["positions"])
 #        self.angles     = np.array(self.h5_file["angles"])
@@ -76,6 +72,13 @@ class H5CommonDataset(Dataset, ABC):
                               offset=self.hdf5_hit_time.id.get_offset(),
                               dtype=self.hdf5_hit_time.dtype)
         self.load_hits()
+
+        # Set attribute so that method won't be invoked again
+        self.initialized = True
+
+        # perform label mapping now that labels have been initialised
+        if self.label_set is not None:
+            self.map_labels(self.label_set)
 
     def map_labels(self, label_set):
         self.label_set = set(label_set)

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -39,6 +39,8 @@ class H5CommonDataset(Dataset, ABC):
         with h5py.File(self.h5_path, 'r') as h5_file:
             self.dataset_length = h5_file["labels"].shape[0]
 
+        self.label_set = None
+
         self.initialized = False
         if not is_distributed:
             self.initialize()

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -81,6 +81,7 @@ class H5CommonDataset(Dataset, ABC):
             labels = np.ndarray(self.labels.shape, dtype=int)
             for i, l in enumerate(self.label_set):
                 labels[self.labels == l] = i
+            self.original_labels = self.labels
             self.labels = labels
 
     @abstractmethod

--- a/watchmal/engine/engine_classifier.py
+++ b/watchmal/engine/engine_classifier.py
@@ -111,7 +111,7 @@ class ClassifierEngine:
         for name, loader_config in loaders_config.items():
             self.data_loaders[name] = get_data_loader(**data_config, **loader_config, is_distributed=is_distributed, seed=seed)
             if self.label_set is not None:
-                self.data_loaders[name].map_labels(self.label_set)
+                self.data_loaders[name].dataset.map_labels(self.label_set)
     
     def get_synchronized_metrics(self, metric_dict):
         """

--- a/watchmal/engine/engine_classifier.py
+++ b/watchmal/engine/engine_classifier.py
@@ -27,7 +27,7 @@ from watchmal.dataset.data_utils import get_data_loader
 from watchmal.utils.logging_utils import CSVData
 
 class ClassifierEngine:
-    def __init__(self, model, rank, gpu, dump_path):
+    def __init__(self, model, rank, gpu, dump_path, label_set):
         """
         Args:
             model       ... model object that engine will use in training or evaluation
@@ -54,6 +54,7 @@ class ClassifierEngine:
             self.model_accs = self.model
 
         self.data_loaders = {}
+        self.label_set = label_set
 
         # define the placeholder attributes
         self.data = None
@@ -108,6 +109,8 @@ class ClassifierEngine:
         """
         for name, loader_config in loaders_config.items():
             self.data_loaders[name] = get_data_loader(**data_config, **loader_config, is_distributed=is_distributed, seed=seed)
+            if self.label_set is not None:
+                self.data_loaders[name].map_labels(self.label_set)
     
     def get_synchronized_metrics(self, metric_dict):
         """

--- a/watchmal/engine/engine_classifier.py
+++ b/watchmal/engine/engine_classifier.py
@@ -27,13 +27,14 @@ from watchmal.dataset.data_utils import get_data_loader
 from watchmal.utils.logging_utils import CSVData
 
 class ClassifierEngine:
-    def __init__(self, model, rank, gpu, dump_path, label_set):
+    def __init__(self, model, rank, gpu, dump_path, label_set=None):
         """
         Args:
             model       ... model object that engine will use in training or evaluation
             rank        ... rank of process among all spawned processes (in multiprocessing mode)
             gpu         ... gpu that this process is running on
             dump_path   ... path to store outputs in
+            label_set   ... set of labels to classify (if None, default, then class labels in the data must be 0 to N)
         """
         # create the directory for saving the log and dump files
         self.epoch = 0.


### PR DESCRIPTION
Adds the ability to map arbitrary class labels from and H5Dataset into the range from 0 to N, where N is the number of labels in the set. This allows training a classifier for any set of labels, to work around the PyTorch requirement that labels run from 0 to N.

To use this option, the classifer engine should set the config parameter `label_set` in the usual Hydra way for a list. If set to None (the default if `label_set` is not specified) then the class labels must already be the range 0 to N. Otherwise, the set of labels can be specified by, e.g.:

```
label_set:
 - 1
 - 2
```

The softmax output columns will correspond to the set of labels provided, in the order they're provided (rows correspond to events). If no label set is provided, and labels are 0 to N, then the columns correspond to these values (i.e. no change from before).