### PR TITLE
Fix resnet50

### DIFF
--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -1,4 +1,5 @@
 import torch.nn as nn
+import torch
 
 
 def conv1x1(in_planes, out_planes, stride=1):

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -100,7 +100,7 @@ class ResNet(nn.Module):
         self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
 
         self.avgpool = nn.AdaptiveAvgPool2d((1,1))
-        self.fc = nn.Linear(512 * block.expansion, num_classes)
+        self.fc = nn.Linear(512 * block.expansion, num_output_channels)
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):


### PR DESCRIPTION
Reverts unnecessary changes made to ResNet Bottleneck implementation a long time ago when working on VAE implementation. Corresponding changes were already made to BasicBlock to fix resnet18 and resnet34 (see PR #53), while the changes to Bottleneck in this PR fix resnet50 and larger, which currently crash (see also issue #61).