### PR TITLE
Resnet circular padding

### DIFF
--- a/config/model/feature_extractor/resnet18.yaml
+++ b/config/model/feature_extractor/resnet18.yaml
@@ -1,4 +1,4 @@
 _target_: watchmal.model.resnet.resnet18
 num_input_channels: 19
 num_output_channels: 4
-conv_pad_mode: 'circular'
+conv_pad_mode: circular

--- a/config/model/feature_extractor/resnet18.yaml
+++ b/config/model/feature_extractor/resnet18.yaml
@@ -1,4 +1,4 @@
 _target_: watchmal.model.resnet.resnet18
 num_input_channels: 19
 num_output_channels: 4
-padding_mode: 'circular'
+conv_pad_mode: 'circular'

--- a/config/model/feature_extractor/resnet18.yaml
+++ b/config/model/feature_extractor/resnet18.yaml
@@ -1,3 +1,4 @@
 _target_: watchmal.model.resnet.resnet18
 num_input_channels: 19
 num_output_channels: 4
+padding_mode: 'circular'

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -15,13 +15,13 @@ def conv3x3(in_planes, out_planes, stride=1, padding_mode='zeros'):
 class BasicBlock(nn.Module):
     expansion = 1
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None, padding_mode='zeros'):
+    def __init__(self, inplanes, planes, stride=1, downsample=None, conv_pad_mode='zeros'):
         super(BasicBlock, self).__init__()
         
-        self.conv1 = conv3x3(inplanes, planes, stride, padding_mode)
+        self.conv1 = conv3x3(inplanes, planes, stride, conv_pad_mode)
         self.bn1 = nn.BatchNorm2d(planes)
         self.relu = nn.ReLU(inplace=True)
-        self.conv2 = conv3x3(planes, planes, padding_mode=padding_mode)
+        self.conv2 = conv3x3(planes, planes, padding_mode=conv_pad_mode)
         self.bn2 = nn.BatchNorm2d(planes)
         self.downsample = downsample
         self.stride = stride
@@ -48,12 +48,12 @@ class BasicBlock(nn.Module):
 class Bottleneck(nn.Module):
     expansion = 4
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None, padding_mode='zeros'):
+    def __init__(self, inplanes, planes, stride=1, downsample=None, conv_pad_mode='zeros'):
         super(Bottleneck, self).__init__()
         
         self.conv1 = conv1x1(inplanes, planes)
         self.bn1 = nn.BatchNorm2d(planes)
-        self.conv2 = conv3x3(planes, planes, stride, padding_mode=padding_mode)
+        self.conv2 = conv3x3(planes, planes, stride, padding_mode=conv_pad_mode)
         self.bn2 = nn.BatchNorm2d(planes)
         self.conv3 = conv1x1(planes, planes * self.expansion)
         self.bn3 = nn.BatchNorm2d(planes * self.expansion)
@@ -85,7 +85,7 @@ class Bottleneck(nn.Module):
 class ResNet(nn.Module):
 
     def __init__(self, block, layers, num_input_channels, num_output_channels, zero_init_residual=False,
-                 padding_mode='zeros'):
+                 conv_pad_mode='zeros'):
 
         super(ResNet, self).__init__()
 
@@ -96,10 +96,10 @@ class ResNet(nn.Module):
         self.relu = nn.ReLU(inplace=True)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
 
-        self.layer1 = self._make_layer(block, 64, layers[0], stride=1, padding_mode)
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2, padding_mode)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2, padding_mode)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2, padding_mode)
+        self.layer1 = self._make_layer(block, 64, layers[0], stride=1, conv_pad_mode=conv_pad_mode)
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2, conv_pad_mode=conv_pad_mode)
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2, conv_pad_mode=conv_pad_mode)
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2, conv_pad_mode=conv_pad_mode)
 
         self.avgpool = nn.AdaptiveAvgPool2d((1,1))
         self.fc = nn.Linear(512 * block.expansion, num_output_channels)
@@ -121,7 +121,7 @@ class ResNet(nn.Module):
                 elif isinstance(m, BasicBlock):
                     nn.init.constant_(m.bn2.weight, 0)
 
-    def _make_layer(self, block, planes, blocks, stride=1, padding_mode='zeros'):
+    def _make_layer(self, block, planes, blocks, stride=1, conv_pad_mode='zeros'):
         downsample = None
         
         if stride != 1 or self.inplanes != planes * block.expansion:
@@ -130,10 +130,10 @@ class ResNet(nn.Module):
                 nn.BatchNorm2d(planes * block.expansion),
             )
         layers = []
-        layers.append(block(self.inplanes, planes, stride, downsample, padding_mode))
+        layers.append(block(self.inplanes, planes, stride, downsample, conv_pad_mode))
         self.inplanes = planes * block.expansion
         for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes, padding_mode=padding_mode))
+            layers.append(block(self.inplanes, planes, conv_pad_mode=conv_pad_mode))
 
         return nn.Sequential(*layers)
 


### PR DESCRIPTION
When using the double cover transformation, the image has circular boundary conditions. This enables the 'circular' padding mode provided by PyTorch to make use of these boundary conditions in its convolution operations.
The extra argument to ResNet model `conv_pad_mode` sets the `padding_mode` of PyTorch's Conv2d function ([see here](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html)). By default is is `zeros` for backward compatibility with older runs that don't set the parameter.
The default config for training when using double cover now sets it to `circular`.
See last slides of presentation [here](https://www.watchmal.org/meetings/internal/2022/2022-12-22/watchmal-code-updates-iwcd-pid-status.pdf/view) for more details.
Benchmarks show improvement over previous runs when enabling the circular convolution padding mode.
![image](https://user-images.githubusercontent.com/9571544/209404585-fc994159-834a-4580-ac81-18a566ca1fb5.png)
![image](https://user-images.githubusercontent.com/9571544/209404590-b7cefa88-90f4-44d8-af6f-78295676b836.png)
![image](https://user-images.githubusercontent.com/9571544/209404689-d7ac4fbf-c2f2-4c07-97ef-57725422c022.png)
![image](https://user-images.githubusercontent.com/9571544/209404696-0c192362-9a7b-4771-b5c9-262877aeb465.png)
