### PR TITLE
ResNet18 Charge and Time last version

### DIFF
--- a/config/data/dataset/iwcd_cnn_short.yaml
+++ b/config/data/dataset/iwcd_cnn_short.yaml
@@ -1,4 +1,8 @@
 _target_: watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset.CNNmPMTDataset
 mpmt_positions_file: /data/WatChMaL/data/IWCDshort_mPMT_image_positions.npz
-collapse_arrays: False
+mode: ['charge', 'time'] # With this configuration: 38 channels (19 for charge + 19 for time)
+#collapse_arrays: False
+#collapse_mode: ['charge', 'time']
 padding_type: double_cover
+scaling_charge: [2.634658, 6.9462004]
+scaling_time: [1115.6687, 263.4307]

--- a/config/data/dataset/iwcd_cnn_short.yaml
+++ b/config/data/dataset/iwcd_cnn_short.yaml
@@ -1,7 +1,6 @@
 _target_: watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset.CNNmPMTDataset
 mpmt_positions_file: /data/WatChMaL/data/IWCDshort_mPMT_image_positions.npz
 mode: ['charge', 'time'] # With this configuration: 38 channels (19 for charge + 19 for time)
-#collapse_arrays: False
 #collapse_mode: ['charge', 'time']
 padding_type: double_cover
 scaling_charge: [2.634658, 6.9462004]

--- a/config/model/feature_extractor/resnet18.yaml
+++ b/config/model/feature_extractor/resnet18.yaml
@@ -1,4 +1,4 @@
 _target_: watchmal.model.resnet.resnet18
-num_input_channels: 19
+num_input_channels: 38
 num_output_channels: 4
 conv_pad_mode: circular

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -166,7 +166,7 @@ class CNNmPMTDataset(H5Dataset):
                  std_channel = torch.std(processed_image, 0, keepdim=True)
                  processed_image = torch.cat((mean_channel, std_channel), 0)
 
-        data_dict["data"] = processed_data
+        data_dict["data"] = processed_image
         
         return data_dict
         

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -26,7 +26,7 @@ class CNNmPMTDataset(H5Dataset):
     with mPMTs arrange in an event-display-like format.
     """
 
-    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, collapse_arrays=False, mode=['charge','time'], collapse_mode=None, scaling_charge=None, scaling_time=None):
+    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, mode=['charge','time'], collapse_mode=None, scaling_charge=None, scaling_time=None):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge data is
         formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to one mPMT
@@ -42,9 +42,6 @@ class CNNmPMTDataset(H5Dataset):
         transforms: sequence of string
             List of random transforms to apply to data before passing to CNN for data augmentation. Each element of the
             list should be the name of a method of this class that performs the transformation
-        collapse_arrays: bool
-            Whether to collapse the image-like CNN arrays to a single channels containing the sum of other channels.
-            i.e. provide the sum of PMT charges in each mPMT instead of providing all PMT charges.
         """
         super().__init__(h5file)
 
@@ -54,7 +51,6 @@ class CNNmPMTDataset(H5Dataset):
                             np.count_nonzero(self.mpmt_positions[:, 0] == row) == self.data_size[1]]
         n_channels = pmts_per_mpmt
         self.data_size = np.insert(self.data_size, 0, n_channels)
-        self.collapse_arrays = collapse_arrays
         self.transforms = du.get_transformations(self, transforms)
 
         if padding_type is not None:
@@ -109,10 +105,6 @@ class CNNmPMTDataset(H5Dataset):
         barrel_data = data[:, self.barrel_rows, :]
         data[:, self.barrel_rows, :] = barrel_data[barrel_map_array_idxs, :, :]
 
-        # collapse arrays if desired
-        #if self.collapse_arrays:
-        #    data = np.expand_dims(np.sum(data, 0), 0)
-        
         return data
 
     def __getitem__(self, item):

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -53,6 +53,7 @@ class CNNmPMTDataset(H5Dataset):
         scaling_time: [offset, scale]
 	    Offset and scale to standardise the PMT time data
         ----------
+	"""
 	
         super().__init__(h5file)
 

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -26,7 +26,7 @@ class CNNmPMTDataset(H5Dataset):
     with mPMTs arrange in an event-display-like format.
     """
 
-    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, collapse_arrays=False):
+    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, collapse_arrays=False, mode=['charge','time'], collapse_mode=None, scaling_charge=None, scaling_time=None):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge data is
         formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to one mPMT
@@ -64,6 +64,21 @@ class CNNmPMTDataset(H5Dataset):
 
         self.horizontal_flip_mpmt_map = [0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 12, 17, 16, 15, 14, 13, 18]
         self.vertical_flip_mpmt_map = [6, 5, 4, 3, 2, 1, 0, 11, 10, 9, 8, 7, 15, 14, 13, 12, 17, 16, 18]
+
+        self.mode = mode
+        self.collapse_mode = collapse_mode
+        self.scaling_charge = scaling_charge
+        self.scaling_time = scaling_time
+
+        if self.scaling_charge is not None:
+            self.charge_offset = self.scaling_charge[0]
+            self.charge_scale = self.scaling_charge[1]
+
+        if self.scaling_time is not None:
+            self.time_offset = self.scaling_time[0]
+            self.time_scale = self.scaling_time[1] 
+            
+
 
     def process_data(self, hit_pmts, hit_data):
         """

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -43,16 +43,17 @@ class CNNmPMTDataset(H5Dataset):
             List of random transforms to apply to data before passing to CNN for data augmentation. Each element of the
             list should be the name of a method of this class that performs the transformation
 	mode: sequence of string
-	    list defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
+	    List defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
         collapse_mode: sequence of string
-	    list of the data to be collapsed to two channels, containing, respectively, the mean and the std of other channels. 
-	i.e. provides the the mean and the std of PMT charges and/or time in each mPMT instead of providing all PMT data.	
-	It can be [], ['charge'], ['time'] or ['charge', 'time']. By default no collapsing is performed.
-        scaling_charge:
-            
-        scaling_time: 
+	    List of the data to be collapsed to two channels, containing, respectively, the mean and the std of other channels. 
+	    i.e. provides the the mean and the std of PMT charges and/or time in each mPMT instead of providing all PMT data.	
+	    It can be [], ['charge'], ['time'] or ['charge', 'time']. By default no collapsing is performed.
+        scaling_charge:[offset, scale]
+	    Offset and scale to standardise the PMT charge data
+        scaling_time: [offset, scale]
+	    Offset and scale to standardise the PMT time data
+        ----------
 	
-        """
         super().__init__(h5file)
 
         self.mpmt_positions = np.load(mpmt_positions_file)['mpmt_image_positions']

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -46,7 +46,7 @@ class CNNmPMTDataset(H5Dataset):
 	    List defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
         collapse_mode: sequence of string
 	    List of the data to be collapsed to two channels, containing, respectively, the mean and the std of other channels. 
-	    i.e. provides the the mean and the std of PMT charges and/or time in each mPMT instead of providing all PMT data.	
+	    i.e. provides the mean and the std of PMT charges and/or time in each mPMT instead of providing all PMT data.	
 	    It can be [], ['charge'], ['time'] or ['charge', 'time']. By default no collapsing is performed.
         scaling_charge:[offset, scale]
 	    Offset and scale to standardise the PMT charge data

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -42,6 +42,8 @@ class CNNmPMTDataset(H5Dataset):
         transforms: sequence of string
             List of random transforms to apply to data before passing to CNN for data augmentation. Each element of the
             list should be the name of a method of this class that performs the transformation
+	mode: sequence of string
+	List defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
         """
         super().__init__(h5file)
 

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -325,6 +325,27 @@ class CNNmPMTDataset(H5Dataset):
 
         return padded_data
 
+    def retrieve_event_data(self, item):
+        """
+        Returns event data from dataset associated with a specific index
+        Args:
+            item                    ... index of event
+        Returns:
+            hit_pmts                ... array of ids of hit pmts
+            pmt_charge_data         ... array of charge of hits
+            pmt_time_data           ... array of times of hits
+        """
+        data_dict = super().__getitem__(item)
+
+        # construct charge data with barrel array indexing to match endcaps in xyz ordering
+        pmt_charge_data = self.process_data(self.event_hit_pmts, self.event_hit_charges).flatten()
+
+        # construct time data with barrel array indexing to match endcaps in xyz ordering
+        pmt_time_data = self.process_data(self.event_hit_pmts, self.event_hit_times).flatten()
+
+        return self.event_hit_pmts, pmt_charge_data, pmt_time_data
+
+	
     def feature_scaling_std(self, hit_array, offset, scale):
         """
             Scale data using standarization.

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -110,8 +110,8 @@ class CNNmPMTDataset(H5Dataset):
         data[:, self.barrel_rows, :] = barrel_data[barrel_map_array_idxs, :, :]
 
         # collapse arrays if desired
-        if self.collapse_arrays:
-            data = np.expand_dims(np.sum(data, 0), 0)
+        #if self.collapse_arrays:
+        #    data = np.expand_dims(np.sum(data, 0), 0)
         
         return data
 

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -315,27 +315,6 @@ class CNNmPMTDataset(H5Dataset):
         padded_data = torch.cat(concat_order, dim=1)
 
         return padded_data
-
-    def retrieve_event_data(self, item):
-        """
-        Returns event data from dataset associated with a specific index
-        Args:
-            item                    ... index of event
-        Returns:
-            hit_pmts                ... array of ids of hit pmts
-            pmt_charge_data         ... array of charge of hits
-            pmt_time_data           ... array of times of hits
-        """
-        data_dict = super().__getitem__(item)
-
-        # construct charge data with barrel array indexing to match endcaps in xyz ordering
-        pmt_charge_data = self.process_data(self.event_hit_pmts, self.event_hit_charges).flatten()
-
-        # construct time data with barrel array indexing to match endcaps in xyz ordering
-        pmt_time_data = self.process_data(self.event_hit_pmts, self.event_hit_times).flatten()
-
-        return self.event_hit_pmts, pmt_charge_data, pmt_time_data
-
 	
     def feature_scaling_std(self, hit_array, offset, scale):
         """

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -175,14 +175,16 @@ class CNNmPMTDataset(H5Dataset):
         Takes image-like data and returns the data after applying a horizontal flip to the image.
         The channels of the PMTs within mPMTs also have the appropriate permutation applied.
         """
-        return flip(data[self.horizontal_flip_mpmt_map, :, :], [2])
+ 	flip_mpmt_map = np.tile(self.horizontal_flip_mpmt_map, data.shape[0]/19)
+        return flip(data[flip_mpmt_map, :, :], [2])
 
     def vertical_flip(self, data):
         """
         Takes image-like data and returns the data after applying a vertical flip to the image.
         The channels of the PMTs within mPMTs also have the appropriate permutation applied.
         """
-        return flip(data[self.vertical_flip_mpmt_map, :, :], [1])
+  	flip_mpmt_map = np.tile(self.vertical_flip_mpmt_map, data.shape[0]/19)
+        return flip(data[flip_mpmt_map, :, :], [1])
 
     def flip_180(self, data):
         """

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -43,7 +43,15 @@ class CNNmPMTDataset(H5Dataset):
             List of random transforms to apply to data before passing to CNN for data augmentation. Each element of the
             list should be the name of a method of this class that performs the transformation
 	mode: sequence of string
-	List defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
+	    list defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
+        collapse_mode: sequence of string
+	    list of the data to be collapsed to two channels, containing, respectively, the mean and the std of other channels. 
+	i.e. provides the the mean and the std of PMT charges and/or time in each mPMT instead of providing all PMT data.	
+	It can be [], ['charge'], ['time'] or ['charge', 'time']. By default no collapsing is performed.
+        scaling_charge:
+            
+        scaling_time: 
+	
         """
         super().__init__(h5file)
 

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -324,3 +324,10 @@ class CNNmPMTDataset(H5Dataset):
         padded_data = torch.cat(concat_order, dim=1)
 
         return padded_data
+
+    def feature_scaling_std(self, hit_array, offset, scale):
+        """
+            Scale data using standarization.
+        """
+        standarized_array = (hit_array - offset)/scale
+        return standarized_array

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -75,7 +75,6 @@ class CNNmPMTDataset(H5Dataset):
             self.time_scale = self.scaling_time[1] 
             
 
-
     def process_data(self, hit_pmts, hit_data):
         """
         Returns event data from dataset associated with a specific index


### PR DESCRIPTION
What?
I have added the code to 1) use time information besides the charge; 2) collapse all the 19 channels of charge and/or time into 2 channels each (made of mean and standard deviation); 3) rescale features in a standardized form.

Why?
Addition has been made to include full information: charge and time for each PMT. Using all data is found to increase the accuracy of the ResNet. Results were reported in WatchMal meetings.

How?
I have introduced four new options in class CNNmPMTDataset: "mode", "collapse_mode", "scaling_charge", "scaling_time"

"mode" can be ['charge', 'time'], ['charge'], ['time']

"collapse_mode" can be [], ['charge', 'time'], ['charge'], ['time']

"scaling_charge" can be [], [mean_value, std_value]

"scaling_time" can be [], [mean_value, std_value]

The previous option "collapse_array" is not used anymore.

The main changes affect the method "process_data".

In particular, according to the content of "mode", I include the charge, the time or both, and eventually I concatenate them together.
According to the content of "collapse_mode", the corresponding channels are rescaled through standardization. For this purpose, the function feature_scaling_std has been introduced. It takes as input mean and std extracted from "scaling_charge" and/or "scaling_time".