### PR TITLE
Revert "ResNet18 Charge and Time last version"

### DIFF
--- a/config/data/dataset/iwcd_cnn_short.yaml
+++ b/config/data/dataset/iwcd_cnn_short.yaml
@@ -1,7 +1,4 @@
 _target_: watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset.CNNmPMTDataset
 mpmt_positions_file: /data/WatChMaL/data/IWCDshort_mPMT_image_positions.npz
-mode: ['charge', 'time'] # With this configuration: 38 channels (19 for charge + 19 for time)
-#collapse_mode: ['charge', 'time']
+collapse_arrays: False
 padding_type: double_cover
-scaling_charge: [2.634658, 6.9462004]
-scaling_time: [1115.6687, 263.4307]

--- a/config/model/feature_extractor/resnet18.yaml
+++ b/config/model/feature_extractor/resnet18.yaml
@@ -1,4 +1,4 @@
 _target_: watchmal.model.resnet.resnet18
-num_input_channels: 38
+num_input_channels: 19
 num_output_channels: 4
 conv_pad_mode: circular

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -26,7 +26,7 @@ class CNNmPMTDataset(H5Dataset):
     with mPMTs arrange in an event-display-like format.
     """
 
-    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, mode=['charge','time'], collapse_mode=None, scaling_charge=None, scaling_time=None):
+    def __init__(self, h5file, mpmt_positions_file, padding_type=None, transforms=None, collapse_arrays=False):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge data is
         formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to one mPMT
@@ -42,19 +42,10 @@ class CNNmPMTDataset(H5Dataset):
         transforms: sequence of string
             List of random transforms to apply to data before passing to CNN for data augmentation. Each element of the
             list should be the name of a method of this class that performs the transformation
-	mode: sequence of string
-	    List defines the PMT data included in the image-like CNN arrays. It can be either 'charge', 'time' or both (default)
-        collapse_mode: sequence of string
-	    List of the data to be collapsed to two channels, containing, respectively, the mean and the std of other channels. 
-	    i.e. provides the mean and the std of PMT charges and/or time in each mPMT instead of providing all PMT data.	
-	    It can be [], ['charge'], ['time'] or ['charge', 'time']. By default no collapsing is performed.
-        scaling_charge:[offset, scale]
-	    Offset and scale to standardise the PMT charge data
-        scaling_time: [offset, scale]
-	    Offset and scale to standardise the PMT time data
-        ----------
-	"""
-	
+        collapse_arrays: bool
+            Whether to collapse the image-like CNN arrays to a single channels containing the sum of other channels.
+            i.e. provide the sum of PMT charges in each mPMT instead of providing all PMT charges.
+        """
         super().__init__(h5file)
 
         self.mpmt_positions = np.load(mpmt_positions_file)['mpmt_image_positions']
@@ -63,6 +54,7 @@ class CNNmPMTDataset(H5Dataset):
                             np.count_nonzero(self.mpmt_positions[:, 0] == row) == self.data_size[1]]
         n_channels = pmts_per_mpmt
         self.data_size = np.insert(self.data_size, 0, n_channels)
+        self.collapse_arrays = collapse_arrays
         self.transforms = du.get_transformations(self, transforms)
 
         if padding_type is not None:
@@ -72,20 +64,6 @@ class CNNmPMTDataset(H5Dataset):
 
         self.horizontal_flip_mpmt_map = [0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 12, 17, 16, 15, 14, 13, 18]
         self.vertical_flip_mpmt_map = [6, 5, 4, 3, 2, 1, 0, 11, 10, 9, 8, 7, 15, 14, 13, 12, 17, 16, 18]
-
-        self.mode = mode
-        self.collapse_mode = collapse_mode
-        self.scaling_charge = scaling_charge
-        self.scaling_time = scaling_time
-
-        if self.scaling_charge is not None:
-            self.charge_offset = self.scaling_charge[0]
-            self.charge_scale = self.scaling_charge[1]
-
-        if self.scaling_time is not None:
-            self.time_offset = self.scaling_time[0]
-            self.time_scale = self.scaling_time[1] 
-            
 
     def process_data(self, hit_pmts, hit_data):
         """
@@ -116,60 +94,24 @@ class CNNmPMTDataset(H5Dataset):
         barrel_data = data[:, self.barrel_rows, :]
         data[:, self.barrel_rows, :] = barrel_data[barrel_map_array_idxs, :, :]
 
+        # collapse arrays if desired
+        if self.collapse_arrays:
+            data = np.expand_dims(np.sum(data, 0), 0)
+        
         return data
 
     def __getitem__(self, item):
 
         data_dict = super().__getitem__(item)
 
-        if 'charge' in self.mode:
-            hit_data = self.event_hit_charges
-            if self.scaling_charge is not None:
-                hit_data = self.feature_scaling_std(hit_data, self.charge_offset, self.charge_scale)
-            
-            charge_image = from_numpy(self.process_data(self.event_hit_pmts, hit_data))
-            charge_image = self.padding_type(charge_image)
+        processed_data = from_numpy(self.process_data(self.event_hit_pmts, self.event_hit_charges))
         
-        if 'time' in self.mode:
-            hit_data = self.event_hit_times
-            if self.scaling_time is not None:
-                hit_data = self.feature_scaling_std(hit_data, self.time_offset, self.time_scale)
+        processed_data = du.apply_random_transformations(self.transforms, processed_data)
 
-            time_image = from_numpy(self.process_data(self.event_hit_pmts, hit_data))
-            time_image = self.padding_type(time_image)
+        if self.padding_type is not None:
+            processed_data = self.padding_type(processed_data)
 
-        # Merge all channels
-        if ('time' in self.mode) and ('charge' in self.mode):
-            processed_image = torch.cat((charge_image, time_image), 0)
-	    processed_image = du.apply_random_transformations(self.transforms, processed_image)
-
-            charge_image = processed_image[:19, :, :]
-	    time_image = processed_image[19:, :, :]
-	    if 'charge' in self.collapse_mode:
-        	 mean_channel = torch.mean(charge_image, 0, keepdim=True)
-                 std_channel = torch.std(charge_image, 0, keepdim=True)
-                 charge_image = torch.cat((mean_channel, std_channel), 0)
-	    if 'time' in self.collapse_mode:
-		 mean_channel = torch.mean(time_image, 0, keepdim=True)
-                 std_channel = torch.std(time_image, 0, keepdim=True)
-                 time_image = torch.cat((mean_channel, std_channel), 0)
-
-	    processed_image = torch.cat((charge_image, time_image), 0)
-
-        elif 'charge' in self.mode:
-            processed_image = du.apply_random_transformations(self.transforms, charge_image)
-	    if 'charge' in self.collapse_mode:
-	        mean_channel = torch.mean(processed_image, 0, keepdim=True)
-                std_channel = torch.std(processed_image, 0, keepdim=True)
-                processed_image = torch.cat((mean_channel, std_channel), 0)
-        else:
-            processed_image = du.apply_random_transformations(self.transforms, time_image)
-	    if 'time' in self.collapse_mode:
-                 mean_channel = torch.mean(processed_image, 0, keepdim=True)
-                 std_channel = torch.std(processed_image, 0, keepdim=True)
-                 processed_image = torch.cat((mean_channel, std_channel), 0)
-
-        data_dict["data"] = processed_image
+        data_dict["data"] = processed_data
         
         return data_dict
         
@@ -178,16 +120,14 @@ class CNNmPMTDataset(H5Dataset):
         Takes image-like data and returns the data after applying a horizontal flip to the image.
         The channels of the PMTs within mPMTs also have the appropriate permutation applied.
         """
- 	flip_mpmt_map = np.tile(self.horizontal_flip_mpmt_map, data.shape[0]/19)
-        return flip(data[flip_mpmt_map, :, :], [2])
+        return flip(data[self.horizontal_flip_mpmt_map, :, :], [2])
 
     def vertical_flip(self, data):
         """
         Takes image-like data and returns the data after applying a vertical flip to the image.
         The channels of the PMTs within mPMTs also have the appropriate permutation applied.
         """
-  	flip_mpmt_map = np.tile(self.vertical_flip_mpmt_map, data.shape[0]/19)
-        return flip(data[flip_mpmt_map, :, :], [1])
+        return flip(data[self.vertical_flip_mpmt_map, :, :], [1])
 
     def flip_180(self, data):
         """
@@ -327,10 +267,3 @@ class CNNmPMTDataset(H5Dataset):
         padded_data = torch.cat(concat_order, dim=1)
 
         return padded_data
-	
-    def feature_scaling_std(self, hit_array, offset, scale):
-        """
-            Scale data using standarization.
-        """
-        standarized_array = (hit_array - offset)/scale
-        return standarized_array


### PR DESCRIPTION
Reverts WatChMaL/WatChMaL#67

It was found that this PR introduced errors due to tabs instead of spaces in some files. Reverting this PR so that main branch has a working version, until the errors can be fixed and the changes from this PR can be merged again.