### PR TITLE
Updates for WCTE

### DIFF
--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -26,7 +26,7 @@ def channel_position_offset(channel, use_new_convention=False):
     """
     channel = channel % 19
     if use_new_convention:
-        theta = (channel > 6)*2*np.pi*(channel-7)/12 + ((channel > 0) & (channel <= 6))*2*np.pi*(channel-1)/6 - np.pi/2
+        theta = (channel > 6)*2*np.pi*(19-channel)/12 + ((channel > 0) & (channel <= 6))*2*np.pi*(7-channel)/6 + np.pi/2
         radius = 0.2*(channel > 0) + 0.2*(channel > 6)
     else:
         theta = (channel < 12)*2*np.pi*channel/12 + ((channel >= 12) & (channel < 18))*2*np.pi*(channel-12)/6

--- a/analysis/event_display/cnn_mpmt_event_display.py
+++ b/analysis/event_display/cnn_mpmt_event_display.py
@@ -7,7 +7,7 @@ from watchmal.dataset.cnn_mpmt.cnn_mpmt_dataset import CNNmPMTDataset, HORIZONTA
 from matplotlib.pyplot import cm
 
 
-def channel_position_offset(channel):
+def channel_position_offset(channel, use_new_convention=False):
     """
     Calculate offset in plotting coordinates for channel of PMT within mPMT.
 
@@ -15,6 +15,9 @@ def channel_position_offset(channel):
     ----------
     channel: array_like of float
         array of channel IDs or PMT IDs
+    use_new_convention: bool
+        use newer convention for the channel mapping of PMTs in the mPMT (starts with central PMT, then middle ring then
+        outer ring) as opposed to old convention (starts with outer ring, then middle ring, then central PMT).
 
     Returns
     -------
@@ -22,13 +25,17 @@ def channel_position_offset(channel):
         Array of (y, x) coordinate offsets
     """
     channel = channel % 19
-    theta = (channel < 12)*2*np.pi*channel/12 + ((channel >= 12) & (channel < 18))*2*np.pi*(channel-12)/6
-    radius = 0.2*(channel < 18) + 0.2*(channel < 12)
+    if use_new_convention:
+        theta = (channel > 6)*2*np.pi*(channel-7)/12 + ((channel > 0) & (channel <= 6))*2*np.pi*(channel-1)/6 - np.pi/2
+        radius = 0.2*(channel > 0) + 0.2*(channel > 6)
+    else:
+        theta = (channel < 12)*2*np.pi*channel/12 + ((channel >= 12) & (channel < 18))*2*np.pi*(channel-12)/6
+        radius = 0.2*(channel < 18) + 0.2*(channel < 12)
     position = np.column_stack((radius*np.sin(theta), radius*np.cos(theta)))
     return position
 
 
-def coordinates_from_data(data):
+def coordinates_from_data(data, use_new_convention=False):
     """
     Calculate plotting coordinates for each element of CNN data, where each element of `data` contains a PMT's data.
     The actual values in `data` don't matter, it just takes the data tensor that has dimensions of
@@ -40,6 +47,9 @@ def coordinates_from_data(data):
     ----------
     data: array_like
         Array of PMT data formatted for use in CNN, i.e. with dimensions of (channel, row, column)
+    use_new_convention: bool
+        use newer convention for the channel mapping of PMTs in the mPMT (starts with central PMT, then middle ring then
+        outer ring) as opposed to old convention (starts with outer ring, then middle ring, then central PMT).
 
     Returns
     -------
@@ -49,7 +59,7 @@ def coordinates_from_data(data):
     indices = np.indices(data.shape)
     channels = indices[0].flatten()
     coordinates = indices[[2, 1]].reshape(2, -1).astype(np.float64).T
-    coordinates += channel_position_offset(channels)
+    coordinates += channel_position_offset(channels, use_new_convention)
     return coordinates
 
 
@@ -101,7 +111,7 @@ class CNNmPMTEventDisplay(CNNmPMTDataset):
             data_nan = self.apply_transform(transforms, {"data": data_nan})["data"]
         if channel is not None:
             data_nan = data_nan[self.channel_ranges[channel]]
-        coordinates = coordinates_from_data(data_nan)  # coordinates corresponding to each element of the data array
+        coordinates = coordinates_from_data(data_nan, self.use_new_mpmt_convention)  # coordinates corresponding to each element of the data array
         # also get the coordinates of the centre PMT (channel 18) where the actual mPMTs are (not nan)
         mpmt_coordinates = coordinates[((~np.isnan(data_nan)) & (np.indices(data_nan.shape)[0] == 18)).flatten()]
         return plot_event_2d(data_nan.flatten(), coordinates, mpmt_coordinates, **kwargs)

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -314,6 +314,11 @@ class CNNmPMTDataset(H5Dataset):
         data[..., -self.endcap_size:, endcap_copy_columns] = bottom_endcap_copy
         # Rotate the bottom and top halves of barrel and concatenate to the top and bottom of the image
         barrel_bottom_flipped, barrel_top_flipped = np.array_split(self.rotate_image(data[self.barrel]), 2, axis=1)
+        # If the endcaps are offset from the middle of the image, need to roll the flipped barrel to keep the same offset
+        offset = self.endcap_left - (self.image_width - self.endcap_right)
+        if offset != 0:
+            barrel_bottom_flipped = np.roll(barrel_bottom_flipped, offset, 2)
+            barrel_top_flipped = np.roll(barrel_top_flipped, offset, 2)
         data_dict["data"] = np.concatenate((barrel_top_flipped, data, barrel_bottom_flipped), axis=1)
         return data_dict
 


### PR DESCRIPTION
This includes updates for new WCTE geometry conventions, and adds the feature to encode the geometry in extra CNN input channels.

The new WCTE simulations use a different convention for numering of PMTs and mPMTs, so these updates handle that.
There are also changes to the transformations to handle the case where the end-caps are placed in the basic event-display style CNN image offset from the barrel, as is the case for WCTE since it has an even number (16) of barrel columns but an odd-numbered (5x5) end-cap size.

The CNNmPMTDataset is updated for its constructor to take the new parameter `use_new_mpmt_convention` (default `False`, maybe change default to `True` if/when new IWCD data also uses the new convention) and the event display code also inherits and handles this parameter. This convention is just for the numbering of PMTs within the mPMT. For WCTE the numbering of mPMTs is also changed but that is handled by the external mPMT positions file (in future could be useful to extract the PMT in mPMT numbering convention into that file too if we don't converge on a single convention for both IWCD and WCTE).

The CNNmPMTDataset also has the new feature to encode the geometry of the detector and provide it to the CNN through extra channels. This requires the 3D geometry file to be provided through the new `geometry_file` constructor parameter. The three new optional channels are `mpmt_position` (x,y,z position of the mPMT's central PMT), `mpmt_direction` (x,y,z unit vector direction of the mPMT's central PMT) and `mpmt_exists` (1 for the 'pixels' of the CNN image where there is an mPMT and 0 where there is none). This allows fully translation invariant CNN models to predict 3D position-dependent values. For WCTE this is sometimes required. Most of the time it's not necessary due to the model not being perfectly translation invariant because of how the detector is projected onto 2D, but might help it learn anyway.

When using geometry encoding channels, augmentation transforms are _not_ be applied to those channels. This is because the augmentation is to effectively generate new event data that for example represents an event that occurred with everything reflected. We apply the equivalent transform to the truth information, since e.g. the direction reconstruction for an event with the data reflected should reconstruct the reflected direction. But if we also reflected the geometry encoding then it would actually no longer represent a different event at all since reflecting the data and reflecting the geometry the data exists in would cancel eachothers effects. For now, this is done by only ever applying reflection transformations to the data channels (not geometry encoding channels) but in future maybe need a more generic way to apply augmentation transforms to only the data channels but other transforms (like double cover) to all channels. I'm not sure how we'd do that unless we had some way to say whether a transform is an augmentation or not, so for now we assume reflections are always for augmentation while double cover etc. are not augmentation.