### PR TITLE
Minor fixes to analysis code

### DIFF
--- a/analysis/classification.py
+++ b/analysis/classification.py
@@ -478,7 +478,8 @@ class WatChMaLClassification(ClassificationRun, WatChMaLOutput):
         """
         Return a discriminator with appropriate scaling of softmax values from multi-class training, given the set of
         signal and background class labels. For each event, the discriminator is the sum the signal softmax values
-        normalised by the sum of signal and background softmax values.
+        normalised by the sum of signal and background softmax values. When the softmax for both signal and background
+        is equal to zero, the discriminator value is set to 0.5.
 
         Parameters
         ----------
@@ -494,7 +495,11 @@ class WatChMaLClassification(ClassificationRun, WatChMaLOutput):
         """
         signal_softmax = combine_softmax(self.softmaxes, signal_labels, self.label_map)
         background_softmax = combine_softmax(self.softmaxes, background_labels, self.label_map)
-        return signal_softmax / (signal_softmax + background_softmax)
+        total_softmax = signal_softmax + background_softmax
+        bad = total_softmax==0
+        signal_softmax[bad]=0.5
+        total_softmax[bad]=1.0
+        return signal_softmax / total_softmax
 
     @property
     def train_log_accuracy(self):

--- a/analysis/classification.py
+++ b/analysis/classification.py
@@ -38,7 +38,7 @@ def combine_softmax(softmaxes, labels, label_map=None):
 
 
 def plot_rocs(runs, signal_labels, background_labels, selection=None, ax=None, fig_size=None, x_label="", y_label="",
-              x_lim=None, y_lim=None, y_log=None, x_log=None, legend='best', mode='rejection', **plot_args):
+              x_lim=None, y_lim=None, y_log=None, x_log=None, legend='best', mode='rejection', auc_digits=3, **plot_args):
     """
     Plot overlaid ROC curves of results from a number of classification runs
 
@@ -76,6 +76,8 @@ def plot_rocs(runs, signal_labels, background_labels, selection=None, ax=None, f
         If `rejection` (default) plot rejection factor (reciprocal of the false positive rate) on the y-axis versus
         signal efficiency (true positive rate) on the x-axis. If `efficiency` plot background mis-ID rate (false
         positive rate) versus signal efficiency (true positive rate) on the x-axis.
+    auc_digits: int, optional
+        Number of decimal places (3 by default) to show for the AUC value printed in the plot label.
     plot_args: optional
         Additional arguments to pass to the `hist` plotting function. Note that these may be overridden by arguments
         defined in `runs`.
@@ -96,7 +98,7 @@ def plot_rocs(runs, signal_labels, background_labels, selection=None, ax=None, f
         fpr, tpr, _ = metrics.roc_curve(selected_signal, selected_discriminator)
         auc = metrics.auc(fpr, tpr)
         args = {**plot_args, **r.plot_args}
-        args['label'] = f"{args['label']} (AUC={auc:.4f})"
+        args['label'] = f"{args['label']} (AUC={auc:.{auc_digits}f})"
         if mode == 'rejection':
             if y_log is None:
                 y_log = True

--- a/analysis/utils/binning.py
+++ b/analysis/utils/binning.py
@@ -120,10 +120,7 @@ def binned_resolutions(binned_residuals, return_errors=True):
     errors: np.ndarray
         array of standard errors on the means of the residuals
     """
-    try:
-        resolutions = np.array([np.quantile(np.abs(x), 0.68) for x in binned_residuals])
-    except IndexError as ex:
-        raise ValueError("Attempted to calculate resolution in a bin with no entries.") from ex
+    resolutions = np.array([np.nanquantile(np.abs(x), 0.68) for x in binned_residuals])
     if return_errors:
         errors = binned_std_errors(binned_residuals)
         return resolutions, errors
@@ -147,10 +144,7 @@ def binned_quantiles(binned_values, quantile):
     np.ndarray
         array of quantiles of the bins' values
     """
-    try:
-        return np.array([np.quantile(x, quantile) for x in binned_values])
-    except IndexError as ex:
-        raise ValueError("Attempted to calculate quantile in a bin with no entries.") from ex
+    return np.array([np.nanquantile(x, quantile) for x in binned_values])
 
 
 def binned_mean(binned_values, return_errors=True):


### PR DESCRIPTION
A few small fixes to analysis code:
- Adds a parameter to choose how many decimals to print for the AUC value when plotting ROC curves (useful as we get closer and closer to 0.99999...)
- Fixes the (very rare) situation where an event has a softmax value of exactly zero for both a signal and background class, because the network is 100% certain that the event belongs to another class. This caused a divide by zero when calculating the relative softmax of signal vs background. Instead it just sets the relative softmax to 0.5 which should be fine in this situation (since that means equal chance of being either signal or background, when the network is sure that it is neither).
- Fix to prevent an exception being raised when plotting resolutions binned by some quantity, but some bin has no events. Instead it returns a nan value for the resolution in that bin so that it is ignored and the resolutions in other bins are still plotted.