### PR TITLE
Allow label mapping when performing classification on somthing other than "labels"

### DIFF
--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -133,6 +133,8 @@ class H5CommonDataset(Dataset, ABC):
             # "root_files": self.root_files[item],
             "indices": item
         }
+        if self.labels_key is not None and self.labels_key not in data_dict:
+            data_dict[self.labels_key] = getattr(self, self.labels_key)[item].copy()
         return data_dict
 
 

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -84,9 +84,9 @@ class H5CommonDataset(Dataset, ABC):
 
         # perform label mapping now that labels have been initialised
         if self.label_set is not None:
-            self.map_labels(self.label_set)
+            self.map_labels(self.label_set, self.labels_key)
 
-    def map_labels(self, label_set):
+    def map_labels(self, label_set, labels_key="labels"):
         """
         Maps the labels of the dataset into a range of integers from 0 up to N-1, where N is the number of unique labels
         in the provided label set.
@@ -96,14 +96,20 @@ class H5CommonDataset(Dataset, ABC):
         label_set: sequence of labels
             Set of all possible labels to map onto the range of integers from 0 to N-1, where N is the number of unique
             labels.
+        labels_key: string
+            Name of the key used for the labels
         """
         self.label_set = set(label_set)
+        self.labels_key = labels_key
         if self.initialized:
-            labels = np.ndarray(self.labels.shape, dtype=int)
+            try:
+                self.original_labels = getattr(self, labels_key)
+            except AttributeError:
+                self.original_labels = np.array(self.h5_file[labels_key])
+            labels = np.ndarray(self.original_labels.shape, dtype=int)
             for i, l in enumerate(self.label_set):
-                labels[self.labels == l] = i
-            self.original_labels = self.labels
-            self.labels = labels
+                labels[self.original_labels == l] = i
+            setattr(self, labels_key, labels)
 
     @abstractmethod
     def load_hits(self):

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -46,7 +46,7 @@ class ClassifierEngine(ReconstructionEngine):
         super().configure_data_loaders(data_config, loaders_config, is_distributed, seed)
         if self.label_set is not None:
             for name in loaders_config.keys():
-                self.data_loaders[name].dataset.map_labels(self.label_set)
+                self.data_loaders[name].dataset.map_labels(self.label_set, self.truth_key)
 
     def forward(self, train=True):
         """


### PR DESCRIPTION
The classification engine already includes two features:
- Configuring the `label_set` that allows automatic mapping of an arbitrary set of labels onto the integers 0 to N, since PyTorch requires class labels to be 0 to N but we need a way to easily train classification of an arbitrary (sub)set of classes.
- Setting the `truth_key` config parameter so that the ground truth target comes from some element of the dictionary provided by the `Dataset`, which does not necessarily have the `"labels"` key.

But these two features could not be used together: the label mapping in the H5 Dataset assumed that it was using the `"labels"` array of the H5 file, which is passed to the engine as the `"labels"` entry in the dictionary returned by `__getitem__`.

These changes allow the classification engine to pass the truth key to the function that performs the mapping, so that it can be correctly by the `H5Dataset`.

This has been tested successfully on WCTE data where the classification task is to predict whether an event was fully contained (which has labels `True` and `False` to be mapped to 0 and 1, stored in a different H5 file key), rather than predicting the usual PID labels (which has integer labels stored in the usual H5 file's `"labels"` key).