### PR TITLE
Implement ViT, several variants of ViT, ViT for double images input and several miscellaneous

### DIFF
--- a/config/data/dataset/hk_cnn.yaml
+++ b/config/data/dataset/hk_cnn.yaml
@@ -1,0 +1,26 @@
+_target_: watchmal.dataset.cnn.cnn_dataset.CNNDataset
+pmt_positions_file: /disk/schen/workspace/WatChMaL/new_HK_20inchPMT_image_positions.npz
+geometry_file:  /disk/schen/workspace/WatChMaL/HK_20inchPMT_real_info.npz
+#collapse_arrays: False
+
+use_times: True
+use_charges: True
+use_padding: False
+padding_to_fixed_dimension: [192,192]
+use_isHit: False
+use_positions: False
+use_orientations: False
+use_invalid_value: False
+use_log_charge: False
+
+#channel_scale_offset:
+#  time: 950
+#  charge: -2
+#  positions: 0
+#  orientations: 0
+#channel_scale_factor:
+#  time: 700
+#  charge: 4
+#  positions: 3000
+#  orientations: 1
+

--- a/config/data/dataset/hk_dit2tvit.yaml
+++ b/config/data/dataset/hk_dit2tvit.yaml
@@ -1,0 +1,29 @@
+_target_: watchmal.dataset.dit2tvit.dit2tvit_dataset.DoubleImageDataset
+h5file: /disk/schen/workspace/train/tiny_pmt_test.h5
+h5file_mpmt: /disk/schen/workspace/train/tiny_mpmt_test.h5
+pmt_positions_file: /disk/schen/workspace/train/PMTmPMT_PMT.npz
+mpmt_positions_file: /disk/schen/workspace/train/PMTmPMT_mPMT.npz
+geometry_file:  /disk/schen/workspace/WatChMaL/HK_20inchPMT_real_info.npz
+#collapse_arrays: False
+
+use_times: True
+use_charges: True
+use_padding: True
+padding_to_fixed_dimension: [192,192]
+use_isHit: False
+use_positions: False
+use_orientations: False
+use_invalid_value: False
+use_log_charge: False
+
+#channel_scale_offset:
+#  time: 950
+#  charge: -2
+#  positions: 0
+#  orientations: 0
+#channel_scale_factor:
+#  time: 700
+#  charge: 4
+#  positions: 3000
+#  orientations: 1
+

--- a/config/data/dataset/hk_vit.yaml
+++ b/config/data/dataset/hk_vit.yaml
@@ -1,0 +1,26 @@
+_target_: watchmal.dataset.cnn.cnn_dataset.CNNDataset
+pmt_positions_file: /disk/schen/workspace/WatChMaL/new_HK_20inchPMT_image_positions.npz
+geometry_file:  /disk/schen/workspace/WatChMaL/HK_20inchPMT_real_info.npz
+#collapse_arrays: False
+
+use_times: True
+use_charges: True
+use_padding: True
+padding_to_fixed_dimension: [192,192]
+use_isHit: False
+use_positions: False
+use_orientations: False
+use_invalid_value: False
+use_log_charge: False
+
+#channel_scale_offset:
+#  time: 950
+#  charge: -2
+#  positions: 0
+#  orientations: 0
+#channel_scale_factor:
+#  time: 700
+#  charge: 4
+#  positions: 3000
+#  orientations: 1
+

--- a/config/data/hk_split.yaml
+++ b/config/data/hk_split.yaml
@@ -1,0 +1,3 @@
+split_path: /disk/schen/workspace/train/e_0_range2gev_5m.npz
+dataset:
+  h5file: /disk/schen/workspace/train/e_0_range2gev_5m.h5

--- a/config/data/hk_split_di.yaml
+++ b/config/data/hk_split_di.yaml
@@ -1,0 +1,1 @@
+split_path: /disk/schen/workspace/train/tiny_mpmt_test.npz

--- a/config/data/hk_test_split.yaml
+++ b/config/data/hk_test_split.yaml
@@ -1,0 +1,3 @@
+split_path: /disk/schen/workspace/train/e_0_range2gev_test.npz
+dataset:
+  h5file: /disk/schen/workspace/train/e_0_range2gev_test.h5

--- a/config/engine/regression_DI.yaml
+++ b/config/engine/regression_DI.yaml
@@ -1,0 +1,3 @@
+_target_: watchmal.engine.regression_DI.RegressionEngine
+target_key: ['energies',]
+target_scale_factor: 2000

--- a/config/engine/regression_merge.yaml
+++ b/config/engine/regression_merge.yaml
@@ -1,0 +1,8 @@
+_target_: watchmal.engine.regression.RegressionEngine
+target_key: ['directions','positions',]
+target_scale_factor: 
+  directions: 1
+  positions: 1300
+target_scale_offset:
+  directions: 0
+  positions: 0

--- a/config/loss/huber_direction.yaml
+++ b/config/loss/huber_direction.yaml
@@ -1,0 +1,3 @@
+_target_: torch.nn.HuberLoss
+delta:  100
+#delta: 50000

--- a/config/loss/huber_merge.yaml
+++ b/config/loss/huber_merge.yaml
@@ -1,0 +1,3 @@
+_target_: torch.nn.HuberLoss
+#delta: 0.1
+delta: 100

--- a/config/loss/huber_momentum.yaml
+++ b/config/loss/huber_momentum.yaml
@@ -1,0 +1,3 @@
+_target_: watchmal.loss.relative_huber.RelativeHuberLoss
+#delta: 0.1
+delta: 0.07

--- a/config/model/resnet152_direction.yaml
+++ b/config/model/resnet152_direction.yaml
@@ -1,0 +1,6 @@
+_target_: watchmal.model.resnet.resnet152
+num_input_channels: 6
+num_output_channels: 3
+conv_pad_mode: zeros
+dropout_p: 0.2
+group_norm: True

--- a/config/model/resnet152_merge.yaml
+++ b/config/model/resnet152_merge.yaml
@@ -1,0 +1,6 @@
+_target_: watchmal.model.resnet.resnet152
+num_input_channels: 3
+num_output_channels: 6
+conv_pad_mode: zeros
+dropout_p: 0
+group_norm: False

--- a/config/model/resnet152_momentum.yaml
+++ b/config/model/resnet152_momentum.yaml
@@ -1,0 +1,6 @@
+_target_: watchmal.model.resnet.resnet152
+num_input_channels: 2
+num_output_channels: 1
+conv_pad_mode: zeros
+dropout_p: 0
+group_norm: False

--- a/config/model/transformer.yaml
+++ b/config/model/transformer.yaml
@@ -1,0 +1,13 @@
+_target_: watchmal.model.vitransformer.ViTRegressor
+
+img_size: [192, 192]
+patch_size: 16
+in_chans: 2
+embed_dim: 1024
+depth: 24
+num_heads: 16
+mlp_ratio: 4.0
+dropout: 0
+droppath: 0.01
+num_output_channels: 1
+use_conv_stem: True

--- a/config/model/transformer_dit2t.yaml
+++ b/config/model/transformer_dit2t.yaml
@@ -1,0 +1,3 @@
+_target_: watchmal.model.T2TViTransformer2I.DualT2T_ViTRegressor
+
+

--- a/config/model/transformer_swin.yaml
+++ b/config/model/transformer_swin.yaml
@@ -1,0 +1,8 @@
+_target_: watchmal.model.SwinTransformer.SwinRegressor
+
+img_size: [192, 192]
+in_chans: 2
+pretrained: False
+num_output_channels: 1
+
+          

--- a/config/model/transformer_t2t.yaml
+++ b/config/model/transformer_t2t.yaml
@@ -1,0 +1,12 @@
+_target_: watchmal.model.T2TViTransformer.T2T_ViTRegressor
+
+img_size: [192, 192]
+in_chans: 2
+embed_dim: 512
+depth: 24
+num_heads: 8
+mlp_ratio: 3.0
+t2t_token_dims: [64,128]
+dropout: 0
+droppath: 0.05
+num_output_channels: 1

--- a/config/optimizers/adamW_momentum.yaml
+++ b/config/optimizers/adamW_momentum.yaml
@@ -1,0 +1,9 @@
+_target_: torch.optim.AdamW
+#lr: 5e-4           
+#weight_decay: 1e-4
+lr: 5e-4
+weight_decay: 3e-4
+#lr: 1e-5
+#weight_decay: 1e-6
+#lr: 5e-5
+#weight_decay: 1e-5

--- a/config/optimizers/adam_direction.yaml
+++ b/config/optimizers/adam_direction.yaml
@@ -1,0 +1,4 @@
+_target_: torch.optim.Adam
+#lr: 0.00005
+lr: 0.0005
+weight_decay: 0.00001

--- a/config/optimizers/adam_merge.yaml
+++ b/config/optimizers/adam_merge.yaml
@@ -1,0 +1,4 @@
+_target_: torch.optim.Adam
+#lr: 0.00005
+lr: 0.0000005
+weight_decay: 0

--- a/config/optimizers/adam_momentum.yaml
+++ b/config/optimizers/adam_momentum.yaml
@@ -1,0 +1,4 @@
+_target_: torch.optim.Adam
+#lr: 0.00005
+lr: 0.000005
+weight_decay: 0.00001

--- a/config/resnet_hk_direction_train.yaml
+++ b/config/resnet_hk_direction_train.yaml
@@ -1,0 +1,20 @@
+gpu_list:
+  - 0
+  - 1
+
+seed: 1111
+dump_path: './outputs/'
+model:
+  num_output_channels: 3
+defaults:
+  - data: hk_split
+  - data/dataset: hk_cnn
+  - model: resnet152_direction
+  - engine: regression_direction
+ # - tasks/restore_state: restore_state_direction
+  - tasks/train: train_resnet  
+  - optimizers@tasks.train.optimizers: adam_direction
+  - loss@tasks.train.loss: huber_direction
+  - sampler@tasks.train.data_loaders.train.sampler: subset_sequential
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_sequential
+  - _self_

--- a/config/resnet_hk_merge_train.yaml
+++ b/config/resnet_hk_merge_train.yaml
@@ -1,0 +1,20 @@
+gpu_list:
+  - 0
+  - 1
+seed: 1111
+dump_path: './outputs/'
+model:
+  num_output_channels: 6
+defaults:
+  - data: hk_split
+  - data/dataset: hk_cnn
+  - model: resnet152_merge
+  - engine: regression_merge
+  - tasks/restore_state: restore_state_merge
+  - tasks/train: train_resnet  
+  - optimizers@tasks.train.optimizers: adam_merge
+  - loss@tasks.train.loss: huber_merge
+  - sampler@tasks.train.data_loaders.train.sampler: subset_random
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_random
+  - _self_
+

--- a/config/resnet_hk_momentum_train.yaml
+++ b/config/resnet_hk_momentum_train.yaml
@@ -1,0 +1,21 @@
+gpu_list:
+  - 0
+  - 1
+seed: 1111
+dump_path: './outputs/'
+model:
+  num_output_channels: 1
+defaults:
+  - data: hk_split
+  - data/dataset: hk_cnn
+  - model: resnet152_momentum
+  - engine: regression_momentum
+ # - tasks/restore_state: restore_state_momentum
+  - tasks/train: train_resnet  
+  - optimizers@tasks.train.optimizers: adamW_momentum
+  - scheduler@tasks.train.scheduler: cosinelr
+  - loss@tasks.train.loss: huber_momentum
+  - sampler@tasks.train.data_loaders.train.sampler: subset_sequential
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_sequential
+  - _self_
+

--- a/config/scheduler/cosinelr.yaml
+++ b/config/scheduler/cosinelr.yaml
@@ -1,0 +1,3 @@
+_target_: torch.optim.lr_scheduler.CosineAnnealingLR
+T_max: 780000     
+eta_min: 1e-7

--- a/config/tasks/evaluate/test.yaml
+++ b/config/tasks/evaluate/test.yaml
@@ -1,4 +1,7 @@
-defaults:
-  - /data_loaders:
-    - test
 report_interval: 10
+
+data_loaders:
+  test:
+    split_key: test_idxs
+    batch_size: 1000
+    num_workers: 16

--- a/config/tasks/restore_state/restore_state_merge.yaml
+++ b/config/tasks/restore_state/restore_state_merge.yaml
@@ -1,0 +1,1 @@
+weight_file: '/disk/schen/workspace/WatChMaL/outputs/2025-05-11/21-52-03/outputs/RegressionEngine_ResNet_BEST.pth'

--- a/config/tasks/restore_state/restore_state_momentum.yaml
+++ b/config/tasks/restore_state/restore_state_momentum.yaml
@@ -1,0 +1,1 @@
+weight_file: '/disk/schen/workspace/WatChMaL/outputs/2025-05-23/16-19-24/outputs/RegressionEngine_ResNet_BEST.pth'

--- a/config/tasks/restore_state/restore_state_tr.yaml
+++ b/config/tasks/restore_state/restore_state_tr.yaml
@@ -1,0 +1,1 @@
+weight_file: '/disk/schen/workspace/WatChMaL/outputs/2025-06-04/14-40-03/outputs/RegressionEngine_T2T_ViTRegressor_BEST.pth'

--- a/config/tasks/train/train_transformer.yaml
+++ b/config/tasks/train/train_transformer.yaml
@@ -1,0 +1,19 @@
+epochs: 20
+
+val_interval: 1000
+num_val_batches: 100
+
+checkpointing: False
+
+data_loaders:
+  train:
+    split_key: train_idxs
+    batch_size: 64
+    num_workers: 16
+    # pre_transforms:
+    #   - random_reflections
+  validation:
+    split_key: val_idxs
+    batch_size: 64
+    num_workers: 16
+    drop_last: True

--- a/config/transformer.yaml
+++ b/config/transformer.yaml
@@ -1,0 +1,20 @@
+gpu_list:
+  - 0
+  - 1
+seed: 8
+dump_path: './outputs/'
+model:
+  num_output_channels: 1
+defaults:
+  - data: hk_split
+  - data/dataset: hk_vit
+  - model: transformer
+  - engine: regression_momentum
+ # - tasks/restore_state: restore_state_tr
+  - tasks/train: train_transformer 
+  - optimizers@tasks.train.optimizers: adamW_momentum
+  - scheduler@tasks.train.scheduler: cosinelr
+  - loss@tasks.train.loss: huber_momentum
+  - sampler@tasks.train.data_loaders.train.sampler: subset_sequential
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_sequential
+  - _self_

--- a/config/transformer_direction.yaml
+++ b/config/transformer_direction.yaml
@@ -1,0 +1,20 @@
+gpu_list:
+  - 0
+  - 1
+seed: 8
+dump_path: './outputs/'
+model:
+  num_output_channels: 3
+defaults:
+  - data: hk_split
+  - data/dataset: hk_vit
+  - model: transformer
+  - engine: regression_direction
+ # - tasks/restore_state: restore_state_tr
+  - tasks/train: train_transformer
+  - optimizers@tasks.train.optimizers: adamW_momentum
+  - scheduler@tasks.train.scheduler: cosinelr
+  - loss@tasks.train.loss: huber_direction
+  - sampler@tasks.train.data_loaders.train.sampler: subset_sequential
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_sequential
+  - _self_

--- a/config/transformer_dit2t.yaml
+++ b/config/transformer_dit2t.yaml
@@ -1,0 +1,20 @@
+gpu_list:
+  - 0
+  - 1
+seed: 8
+dump_path: './outputs/'
+model:
+  num_output_channels: 1
+defaults:
+  - data: hk_split_di
+  - data/dataset: hk_dit2tvit
+  - model: transformer_dit2t
+  - engine: regression_DI
+ # - tasks/restore_state: restore_state_tr
+  - tasks/train: train_transformer
+  - optimizers@tasks.train.optimizers: adamW_momentum
+  - scheduler@tasks.train.scheduler: cosinelr
+  - loss@tasks.train.loss: huber_momentum
+  - sampler@tasks.train.data_loaders.train.sampler: subset_sequential
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_sequential
+  - _self_

--- a/config/transformer_swin.yaml
+++ b/config/transformer_swin.yaml
@@ -1,0 +1,20 @@
+gpu_list:
+  - 0
+  - 1
+seed: 8
+dump_path: './outputs/'
+model:
+  num_output_channels: 1
+defaults:
+  - data: hk_split
+  - data/dataset: hk_vit
+  - model: transformer_swin
+  - engine: regression_momentum
+ # - tasks/restore_state: restore_state_tr
+  - tasks/train: train_transformer
+  - optimizers@tasks.train.optimizers: adamW_momentum
+  - scheduler@tasks.train.scheduler: cosinelr
+  - loss@tasks.train.loss: huber_momentum
+  - sampler@tasks.train.data_loaders.train.sampler: subset_sequential
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_sequential
+  - _self_

--- a/config/transformer_swinttest.yaml
+++ b/config/transformer_swinttest.yaml
@@ -1,0 +1,18 @@
+gpu_list: 
+  - 0
+#  - 1
+#  - 1
+seed: null
+dump_path: './outputs/'
+model:
+  num_output_channels: 1
+defaults:
+  - data: hk_test_split
+  - data/dataset: hk_vit
+  - model: transformer_swin
+  - engine: regression_momentum
+  - tasks/restore_state: restore_state_tr
+  - tasks/evaluate: test
+  - loss@tasks.evaluate.loss: huber_momentum
+  - sampler@tasks.evaluate.data_loaders.test.sampler: subset_sequential
+  - _self_

--- a/config/transformer_t2t.yaml
+++ b/config/transformer_t2t.yaml
@@ -1,0 +1,20 @@
+gpu_list:
+  - 0
+  - 1
+seed: 8
+dump_path: './outputs/'
+model:
+  num_output_channels: 1
+defaults:
+  - data: hk_split
+  - data/dataset: hk_vit
+  - model: transformer_t2t
+  - engine: regression_momentum
+ # - tasks/restore_state: restore_state_tr
+  - tasks/train: train_transformer
+  - optimizers@tasks.train.optimizers: adamW_momentum
+  - scheduler@tasks.train.scheduler: cosinelr
+  - loss@tasks.train.loss: huber_momentum
+  - sampler@tasks.train.data_loaders.train.sampler: subset_sequential
+  - sampler@tasks.train.data_loaders.validation.sampler: subset_sequential
+  - _self_

--- a/config/transformer_t2ttest.yaml
+++ b/config/transformer_t2ttest.yaml
@@ -1,0 +1,18 @@
+gpu_list: 
+  - 0
+#  - 1
+#  - 1
+seed: null
+dump_path: './outputs/'
+model:
+  num_output_channels: 1
+defaults:
+  - data: hk_test_split
+  - data/dataset: hk_vit
+  - model: transformer_t2t
+  - engine: regression_momentum
+  - tasks/restore_state: restore_state_tr
+  - tasks/evaluate: test
+  - loss@tasks.evaluate.loss: huber_momentum
+  - sampler@tasks.evaluate.data_loaders.test.sampler: subset_sequential
+  - _self_

--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -9,6 +9,7 @@ from torch import from_numpy
 # generic imports
 import numpy as np
 
+np.set_printoptions(threshold=np.inf)
 # WatChMaL imports
 from watchmal.dataset.h5_dataset import H5Dataset
 import watchmal.dataset.data_utils as du
@@ -22,7 +23,26 @@ class CNNDataset(H5Dataset):
     event-display-like format.
     """
 
-    def __init__(self, h5file, pmt_positions_file, use_times=True, use_charges=True, transforms=None, one_indexed=False, use_memmap=True):
+    def __init__(
+        self,
+        h5file,
+        pmt_positions_file,
+        use_times=True,
+        use_charges=True,
+        use_padding=False,
+        padding_to_fixed_dimension=[192, 192],
+        transforms=None,
+        one_indexed=False,
+        use_memmap=True,
+        channel_scale_factor=None,
+        channel_scale_offset=None,
+        use_isHit=False,
+        use_positions=False,
+        use_orientations=False,
+        geometry_file=None,
+        use_invalid_value=False,
+        use_log_charge=False,
+    ):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge and/or time
         data is formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to
@@ -47,27 +67,105 @@ class CNNDataset(H5Dataset):
             indexes). By default, zero-indexing is assumed.
         use_memmap: bool
             Use a memmap and load data into memory as needed (default), otherwise load entire dataset at initialisation
+        ---------- The following features are used for
+        channel_scale_factor: dict of float
+            Dictionary with keys corresponding to channels and values contain the factors to divide that channel.
+            By default, no scaling is applied.
+        channel_scale_offset: dict of float
+            Dictionary with keys corresponding to channels and values contain the offsets to subtract from that channel.
+            By default, no scaling is applied.
+        use_isHit: bool
+            Whether to use a channel to tag the PMT hit or not.
+        use_positions: bool
+            Whether to use three channels to add the real positions info of PMTs.
+        use_orientations: bool
+            Whether to use three channels to add the real orientations info of PMTs.
+        geometry_file: string
+            Location of an npz file containing the real positions and orientations info.
+        use_invalid_value: bool
+            Whether to set all the channel of unhit as an invalid value (like -100).
+        use_log_charge: bool
+            Whether to logarithmically transform the charge.
+        ---------- The following features are used for Visual Transformer. 
+        Because in ViT we need to devide the image, the original image size is 191*191 (HK 20inch PMT), so here we directly pad the image to 192*192, which is more easy to be divided. 
+        use_padding: bool
+            Whether to pad the data to a fixed dimension (default: False).
+        padding_to_fixed_dimension: list of int
+            If use_padding is True, this specifies the fixed dimension to which the data will be padded.
+            Default: [192, 192] (for 192x192 images).
+        ----------
         """
+
         super().__init__(h5file, use_memmap)
-        
-        self.pmt_positions = np.load(pmt_positions_file)['pmt_image_positions']
+
+        self.pmt_positions = np.load(pmt_positions_file)["pmt_image_positions"].astype(
+            int
+        )
         self.use_times = use_times
         self.use_charges = use_charges
+        self.use_isHit = use_isHit
+        self.use_positions = use_positions
+        self.use_orientations = use_orientations
+        self.use_invalid_value = use_invalid_value
+        self.use_log_charge = use_log_charge
         self.data_size = np.max(self.pmt_positions, axis=0) + 1
-        self.barrel_rows = [row for row in range(self.data_size[0]) if
-                            np.count_nonzero(self.pmt_positions[:, 0] == row) == self.data_size[1]]
-        self.transforms = None #du.get_transformations(transformations, transforms)
+        if use_padding:
+            self.data_size = padding_to_fixed_dimension
+        self.barrel_rows = [
+            row
+            for row in range(self.data_size[0])
+            if np.count_nonzero(self.pmt_positions[:, 0] == row) == self.data_size[1]
+        ]
+        self.transforms = None  # du.get_transformations(transformations, transforms)
         self.one_indexed = one_indexed
 
-        n_channels = 0
+        if use_positions:
+            self.real_3Dpositions = np.load(geometry_file)["positions"]
+        else:
+            self.real_3Dpositions = None
+        if use_orientations:
+            self.real_3Dorientations = np.load(geometry_file)["orientations"]
+        else:
+            self.real_3Dorientations = None
+
+        if channel_scale_offset is None:
+            channel_scale_offset = {}
+        self.scale_offset = channel_scale_offset
+        if channel_scale_factor is None:
+            channel_scale_factor = {}
+        self.scale_factor = channel_scale_factor
+
+        self.channel_map = {}
+        current_channel = 0
+
         if use_times:
-            n_channels += 1
+            self.channel_map["time"] = current_channel
+            current_channel += 1
+
         if use_charges:
-            n_channels += 1
-        if n_channels == 0:
-            raise Exception("Please set 'use_times' and/or 'use_charges' to 'True' in your data config.")
-       
-        self.data_size = np.insert(self.data_size, 0, n_channels)
+            self.channel_map["charge"] = current_channel
+            current_channel += 1
+
+        if use_isHit:
+            self.channel_map["isHit"] = current_channel
+            current_channel += 1
+
+        if use_positions:
+            self.channel_map["position_X"] = current_channel
+            self.channel_map["position_Y"] = current_channel + 1
+            self.channel_map["position_Z"] = current_channel + 2
+            current_channel += 3
+
+        if use_orientations:
+            self.channel_map["orientation_X"] = current_channel
+            self.channel_map["orientation_Y"] = current_channel + 1
+            self.channel_map["orientation_Z"] = current_channel + 2
+            current_channel += 3
+        if "time" not in self.channel_map and "charge" not in self.channel_map:
+            raise ValueError("No time or charge information loaded.")
+
+        self.n_channels = current_channel
+        self.data_size = np.insert(self.data_size, 0, self.n_channels)
 
     def process_data(self, hit_pmts, hit_times, hit_charges):
         """
@@ -81,36 +179,97 @@ class CNNDataset(H5Dataset):
             Array of PMT hit times
         hit_charges: array_like of float
             Array of PMT hit charges
-        
+
         Returns
         -------
         data: ndarray
             Array in image-like format (channels, rows, columns) for input to CNN network.
         """
         if self.one_indexed:
-            hit_pmts = hit_pmts-1  # SK cable numbers start at 1
+            hit_pmts = hit_pmts - 1  # SK cable numbers start at 1
 
         hit_rows = self.pmt_positions[hit_pmts, 0]
         hit_cols = self.pmt_positions[hit_pmts, 1]
 
-        data = np.zeros(self.data_size, dtype=np.float32)
+        invalid_value = 0.0
+        if self.use_invalid_value:
+            invalid_value = -100.0
 
-        if self.use_times and self.use_charges:
-            data[0, hit_rows, hit_cols] = hit_times
-            data[1, hit_rows, hit_cols] = hit_charges
-        elif self.use_times:
-            data[0, hit_rows, hit_cols] = hit_times
-        else:
-            data[0, hit_rows, hit_cols] = hit_charges
+        time_offset = self.scale_offset.get("time", 0.0)
+        time_scale = self.scale_factor.get("time", 1.0)
+        charge_offset = self.scale_offset.get("charge", 0.0)
+        charge_scale = self.scale_factor.get("charge", 1.0)
+        positions_offset = self.scale_offset.get("positions", 0.0)
+        positions_scale = self.scale_factor.get("positions", 1.0)
+        orientations_offset = self.scale_offset.get("orientations", 0.0)
+        orientations_scale = self.scale_factor.get("orientations", 1.0)
+
+        if self.use_log_charge:
+            hit_charges = np.log10(hit_charges)
+        data = np.full(self.data_size, invalid_value, dtype=np.float32)
+        if self.use_positions:
+            data[
+                self.channel_map["position_X"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 0] - positions_offset) / positions_scale
+            data[
+                self.channel_map["position_Y"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 1] - positions_offset) / positions_scale
+            data[
+                self.channel_map["position_Z"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 2] - positions_offset) / positions_scale
+        if self.use_orientations:
+            data[
+                self.channel_map["orientation_X"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 0] - orientations_offset
+            ) / orientations_scale
+            data[
+                self.channel_map["orientation_Y"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 1] - orientations_offset
+            ) / orientations_scale
+            data[
+                self.channel_map["orientation_Z"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 2] - orientations_offset
+            ) / orientations_scale
+
+        if "time" in self.channel_map:
+            data[self.channel_map["time"], hit_rows, hit_cols] = (
+                hit_times - time_offset
+            ) / time_scale
+        if "charge" in self.channel_map:
+            data[self.channel_map["charge"], hit_rows, hit_cols] = (
+                hit_charges - charge_offset
+            ) / charge_scale
+        if "isHit" in self.channel_map:
+            data[self.channel_map["isHit"], hit_rows, hit_cols] = 1.0
 
         return data
 
     def __getitem__(self, item):
-
         data_dict = super().__getitem__(item)
 
-        processed_data = from_numpy(self.process_data(self.event_hit_pmts, self.event_hit_times, self.event_hit_charges))
-        processed_data = du.apply_random_transformations(self.transforms, processed_data)
+        processed_data = from_numpy(
+            self.process_data(
+                self.event_hit_pmts, self.event_hit_times, self.event_hit_charges
+            )
+        )
+        processed_data = du.apply_random_transformations(
+            self.transforms, processed_data
+        )
 
         data_dict["data"] = processed_data
 

--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -67,7 +67,7 @@ class CNNDataset(H5Dataset):
             indexes). By default, zero-indexing is assumed.
         use_memmap: bool
             Use a memmap and load data into memory as needed (default), otherwise load entire dataset at initialisation
-        ---------- The following features are used for
+        ---------- The following features are used for optimization.
         channel_scale_factor: dict of float
             Dictionary with keys corresponding to channels and values contain the factors to divide that channel.
             By default, no scaling is applied.

--- a/watchmal/dataset/dit2tvit/dit2tvit_dataset.py
+++ b/watchmal/dataset/dit2tvit/dit2tvit_dataset.py
@@ -1,0 +1,331 @@
+"""
+Here is a dataset class for Double-Image T2T-ViT.
+This class is adapted from CNNDataset to handle double images.
+(Like the 20inch PMT images and mPMT images)
+"""
+
+# torch imports
+from torch import from_numpy
+
+# generic imports
+import numpy as np
+
+np.set_printoptions(threshold=np.inf)
+# WatChMaL imports
+from watchmal.dataset.h5_dataset import H5Dataset
+import watchmal.dataset.data_utils as du
+
+
+class DoubleImageDataset(H5Dataset):
+    def __init__(
+        self,
+        h5file,
+        h5file_mpmt,
+        pmt_positions_file,
+        mpmt_positions_file,
+        use_times=True,
+        use_charges=True,
+        use_padding=False,
+        padding_to_fixed_dimension=[192, 192],
+        transforms=None,
+        one_indexed=False,
+        use_memmap=True,
+        channel_scale_factor=None,
+        channel_scale_offset=None,
+        use_isHit=False,
+        use_positions=False,
+        use_orientations=False,
+        geometry_file=None,
+        use_invalid_value=False,
+        use_log_charge=False,
+    ):
+        """
+        Parameters:
+        ----------
+        h5file_mpmt: string
+            Location of the HDF5 file containing the event data of the mPMT
+        mpmt_positions_file: string
+            Location of an npz file containing the mapping from mPMT IDs to CNN image pixel locations
+        Other parameters are similar to those in CNNDataset.
+        """
+        super().__init__(h5file, use_memmap)
+        self.mpmt_dataset = H5Dataset(h5file_mpmt, use_memmap)
+        self.pmt_positions = np.load(pmt_positions_file)["pmt_image_positions"].astype(
+            int
+        )
+        self.mpmt_positions = np.load(mpmt_positions_file)[
+            "pmt_image_positions"
+        ].astype(int)
+        self.use_times = use_times
+        self.use_charges = use_charges
+        self.use_isHit = use_isHit
+        self.use_positions = use_positions
+        self.use_orientations = use_orientations
+        self.use_invalid_value = use_invalid_value
+        self.use_log_charge = use_log_charge
+        self.data_size = np.max(self.pmt_positions, axis=0) + 1
+        self.data_size_mpmt = np.max(self.mpmt_positions, axis=0) + 1
+        if use_padding:
+            self.data_size = padding_to_fixed_dimension
+            self.data_size_mpmt = padding_to_fixed_dimension
+
+        self.barrel_rows = [
+            row
+            for row in range(self.data_size[0])
+            if np.count_nonzero(self.pmt_positions[:, 0] == row) == self.data_size[1]
+        ]
+        self.transforms = None  # du.get_transformations(transformations, transforms)p
+        self.one_indexed = one_indexed
+
+        # TODO: geometry file for mPMT hasn't been down
+        if use_positions:
+            self.real_3Dpositions = np.load(geometry_file)["positions"]
+        else:
+            self.real_3Dpositions = None
+        if use_orientations:
+            self.real_3Dorientations = np.load(geometry_file)["orientations"]
+        else:
+            self.real_3Dorientations = None
+
+        if channel_scale_offset is None:
+            channel_scale_offset = {}
+        self.scale_offset = channel_scale_offset
+        if channel_scale_factor is None:
+            channel_scale_factor = {}
+        self.scale_factor = channel_scale_factor
+
+        self.channel_map = {}
+        current_channel = 0
+
+        if use_times:
+            self.channel_map["time"] = current_channel
+            current_channel += 1
+
+        if use_charges:
+            self.channel_map["charge"] = current_channel
+            current_channel += 1
+
+        if use_isHit:
+            self.channel_map["isHit"] = current_channel
+            current_channel += 1
+
+        if use_positions:
+            self.channel_map["position_X"] = current_channel
+            self.channel_map["position_Y"] = current_channel + 1
+            self.channel_map["position_Z"] = current_channel + 2
+            current_channel += 3
+
+        if use_orientations:
+            self.channel_map["orientation_X"] = current_channel
+            self.channel_map["orientation_Y"] = current_channel + 1
+            self.channel_map["orientation_Z"] = current_channel + 2
+            current_channel += 3
+        if "time" not in self.channel_map and "charge" not in self.channel_map:
+            raise ValueError("No time or charge information loaded.")
+
+        self.n_channels = current_channel
+        self.n_channels_mpmt = 38
+        self.data_size = np.insert(self.data_size, 0, self.n_channels)
+        self.data_size_mpmt = np.insert(self.data_size_mpmt, 0, self.n_channels_mpmt)
+
+    def process_data_main(self, hit_pmts, hit_times, hit_charges):
+        """
+        Returns event data from dataset associated with a specific index
+
+        Parameters
+        ----------
+        hit_pmts: array_like of int
+            Array of hit PMT IDs
+        hit_times: array_like of float
+            Array of PMT hit times
+        hit_charges: array_like of float
+            Array of PMT hit charges
+
+        Returns
+        -------
+        data: ndarray
+            Array in image-like format (channels, rows, columns) for input to CNN network.
+        """
+        if self.one_indexed:
+            hit_pmts = hit_pmts - 1  # SK cable numbers start at 1
+
+        hit_rows = self.pmt_positions[hit_pmts, 0]
+        hit_cols = self.pmt_positions[hit_pmts, 1]
+
+        invalid_value = 0.0
+        if self.use_invalid_value:
+            invalid_value = -100.0
+
+        time_offset = self.scale_offset.get("time", 0.0)
+        time_scale = self.scale_factor.get("time", 1.0)
+        charge_offset = self.scale_offset.get("charge", 0.0)
+        charge_scale = self.scale_factor.get("charge", 1.0)
+        positions_offset = self.scale_offset.get("positions", 0.0)
+        positions_scale = self.scale_factor.get("positions", 1.0)
+        orientations_offset = self.scale_offset.get("orientations", 0.0)
+        orientations_scale = self.scale_factor.get("orientations", 1.0)
+
+        if self.use_log_charge:
+            hit_charges = np.log10(hit_charges)
+        data = np.full(self.data_size, invalid_value, dtype=np.float32)
+        if self.use_positions:
+            data[
+                self.channel_map["position_X"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 0] - positions_offset) / positions_scale
+            data[
+                self.channel_map["position_Y"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 1] - positions_offset) / positions_scale
+            data[
+                self.channel_map["position_Z"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 2] - positions_offset) / positions_scale
+        if self.use_orientations:
+            data[
+                self.channel_map["orientation_X"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 0] - orientations_offset
+            ) / orientations_scale
+            data[
+                self.channel_map["orientation_Y"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 1] - orientations_offset
+            ) / orientations_scale
+            data[
+                self.channel_map["orientation_Z"],
+                self.pmt_positions[:, 0],
+                self.pmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 2] - orientations_offset
+            ) / orientations_scale
+
+        if "time" in self.channel_map:
+            data[self.channel_map["time"], hit_rows, hit_cols] = (
+                hit_times - time_offset
+            ) / time_scale
+        if "charge" in self.channel_map:
+            data[self.channel_map["charge"], hit_rows, hit_cols] = (
+                hit_charges - charge_offset
+            ) / charge_scale
+
+        if "isHit" in self.channel_map:
+            data[self.channel_map["isHit"], hit_rows, hit_cols] = 1.0
+
+        return data
+
+    def process_data_second(self, hit_pmts, hit_times, hit_charges):
+        """
+        Returns second image (e.g., mPMT-based) event data formatted for CNN input.
+        """
+        if self.one_indexed:
+            hit_pmts = hit_pmts - 1
+
+        hit_rows = self.mpmt_positions[hit_pmts, 0]
+        hit_cols = self.mpmt_positions[hit_pmts, 1]
+
+        invalid_value = 0.0
+        if self.use_invalid_value:
+            invalid_value = -100.0
+
+        time_offset = self.scale_offset.get("time", 0.0)
+        time_scale = self.scale_factor.get("time", 1.0)
+        charge_offset = self.scale_offset.get("charge", 0.0)
+        charge_scale = self.scale_factor.get("charge", 1.0)
+        positions_offset = self.scale_offset.get("positions", 0.0)
+        positions_scale = self.scale_factor.get("positions", 1.0)
+        orientations_offset = self.scale_offset.get("orientations", 0.0)
+        orientations_scale = self.scale_factor.get("orientations", 1.0)
+
+        if self.use_log_charge:
+            hit_charges = np.log10(hit_charges)
+
+        data = np.full(self.data_size_mpmt, invalid_value, dtype=np.float32)
+
+        if self.use_positions:
+            data[
+                self.channel_map["position_X"],
+                self.mpmt_positions[:, 0],
+                self.mpmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 0] - positions_offset) / positions_scale
+            data[
+                self.channel_map["position_Y"],
+                self.mpmt_positions[:, 0],
+                self.mpmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 1] - positions_offset) / positions_scale
+            data[
+                self.channel_map["position_Z"],
+                self.mpmt_positions[:, 0],
+                self.mpmt_positions[:, 1],
+            ] = (self.real_3Dpositions[:, 2] - positions_offset) / positions_scale
+
+        if self.use_orientations:
+            data[
+                self.channel_map["orientation_X"],
+                self.mpmt_positions[:, 0],
+                self.mpmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 0] - orientations_offset
+            ) / orientations_scale
+            data[
+                self.channel_map["orientation_Y"],
+                self.mpmt_positions[:, 0],
+                self.mpmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 1] - orientations_offset
+            ) / orientations_scale
+            data[
+                self.channel_map["orientation_Z"],
+                self.mpmt_positions[:, 0],
+                self.mpmt_positions[:, 1],
+            ] = (
+                self.real_3Dorientations[:, 2] - orientations_offset
+            ) / orientations_scale
+
+        if "time" in self.channel_map:
+            data[(hit_pmts % 19) * 2, hit_rows, hit_cols] = (
+                hit_times - time_offset
+            ) / time_scale
+        if "charge" in self.channel_map:
+            data[(hit_pmts % 19) * 2 + 1, hit_rows, hit_cols] = (
+                hit_charges - charge_offset
+            ) / charge_scale
+        if "isHit" in self.channel_map:
+            data[self.channel_map["isHit"], hit_rows, hit_cols] = 1.0
+
+        return data
+
+    def __getitem__(self, item):
+        if not self.initialized:
+            self.initialize()
+        if not self.mpmt_dataset.initialized:
+            self.mpmt_dataset.initialize()
+        data_dict = super().__getitem__(item)
+
+        data_main = from_numpy(
+            self.process_data_main(
+                self.event_hit_pmts, self.event_hit_times, self.event_hit_charges
+            )
+        )
+        if self.transforms:
+            data_main = du.apply_random_transformations(self.transforms, data_main)
+        mpmt_record = self.mpmt_dataset[item]
+        data_second = from_numpy(
+            self.process_data_second(
+                self.mpmt_dataset.event_hit_pmts,
+                self.mpmt_dataset.event_hit_times,
+                self.mpmt_dataset.event_hit_charges,
+            )
+        )
+
+        data_dict["data_main"] = data_main  # e.g. shape [2, 192, 192]
+        data_dict["data_second"] = data_second  # e.g. shape [38, 192, 192]
+
+        return data_dict

--- a/watchmal/engine/regression_DI.py
+++ b/watchmal/engine/regression_DI.py
@@ -1,0 +1,106 @@
+'''
+Here is adapted from regression.py to work with double image input.
+'''
+import torch
+
+from watchmal.engine.reconstruction import ReconstructionEngine
+from collections.abc import Mapping
+
+# define some useful metrics for different regression targets
+metric_functions = {
+    'positions':  # mean 3D position error
+        lambda x, y: torch.mean(torch.linalg.vector_norm(x-y, dim=1)),
+    'directions':  # mean angle between directions
+        lambda x, y: torch.mean(torch.arccos(torch.clamp(torch.sum(x*y, dim=-1)
+                                                         / torch.linalg.vector_norm(x, dim=-1), -1, 1))),
+    'angles':  # mean angle between directions
+        lambda x, y: torch.mean(torch.arccos(torch.cos(x[:, 0])*torch.cos(y[:, 0])
+                                             + torch.sin(x[:, 0])*torch.sin(y[:, 0])*torch.cos(x[:, 1]-y[:, 1]))),
+    'energies':  # mean fractional error
+        lambda x, y: torch.mean((x - y) / y),
+}
+
+
+class RegressionEngine(ReconstructionEngine):
+    """Engine for performing training or evaluation for a regression network."""
+    def __init__(self, target_key, model, rank, device, dump_path, target_scale_offset=0, target_scale_factor=1):
+        """
+        Parameters
+        ==========
+        target_key : string
+            Name of the key for the target values in the dictionary returned by the dataloader
+        model
+            `nn.module` object that contains the full network that the engine will use in training or evaluation.
+        rank : int
+            The rank of process among all spawned processes (in multiprocessing mode).
+        device : int
+            The gpu that this process is running on.
+        dump_path : string
+            The path to store outputs in.
+        target_scale_offset : float or dict of float
+            Offset to subtract from target values when calculating the loss, or dict of offsets for each target
+        target_scale_factor : float or dict of float
+            Scale factor to divide target values by when calculating the loss, or dict of scale factors for each target
+        """
+        # create the directory for saving the log and dump files
+        super().__init__(target_key, model, rank, device, dump_path)
+        if isinstance(self.target_key, str):
+            self.target_key = [self.target_key]
+        self.target_sizes = None
+        if isinstance(target_scale_offset, Mapping):  # each target has its own offset
+            self.offset = {t: torch.tensor(target_scale_offset.get(t, 0)).to(self.device) for t in target_key}
+        else:  # each target has the same offset
+            self.offset = {t: torch.tensor(target_scale_offset).to(self.device) for t in target_key}
+        if isinstance(target_scale_factor, Mapping):  # each target has its own scale
+            self.scale = {t: torch.tensor(target_scale_factor.get(t, 1)).to(self.device) for t in target_key}
+        else:  # each target has the same scale
+            self.scale = {t: torch.tensor(target_scale_factor).to(self.device) for t in target_key}
+
+    def process_data(self, data):
+        """Extract the event data and target from the input data dict"""
+        self.data_main   = data["data_main"].to(self.device)    # [B, 2, 192,192]
+        self.data_second = data["data_second"].to(self.device)  # [B,38,192,192]
+        self.target = {t: data[t].to(self.device) for t in self.target_key}
+        # First time we get data, determine the target sizes
+        if self.target_sizes is None:
+            self.target_sizes = [v.shape[1] if len(v.shape) > 1 else 1 for v in self.target.values()]
+
+    def forward(self, train=True):
+        """
+        Compute predictions and metrics for a batch of data
+
+        Parameters
+        ==========
+        train : bool
+            Whether in training mode, requiring computing gradients for backpropagation
+
+        Returns
+        =======
+        dict
+            Dictionary containing loss and predicted values
+        """
+        with torch.set_grad_enabled(train):
+            # scale and stack the targets for calculating the loss
+            target = torch.column_stack([(v - self.offset[t]) / self.scale[t] for t, v in self.target.items()])
+            # evaluate the model on the data and reshape output to match the target
+            model_out = self.model(self.data_main, self.data_second).reshape(target.shape)
+            print(['Val', 'Train'][train], end='\t')
+            print(f'M:{model_out[0].tolist()};T:{target[0].tolist()}')
+            # calculate the loss
+            target = target.to(torch.float32)
+            model_out = model_out.to(torch.float32)
+            self.loss = self.criterion(model_out, target)
+            # split the output for each target
+            split_model_out = torch.split(model_out, self.target_sizes, dim=1)
+            # return outputs including the unscaled target dictionary plus elements for the corresponding predictions
+            outputs = self.target.copy()
+            predicted_dict = {
+                "predicted_" + t: o * self.scale[t] + self.offset[t]
+                for t, o in zip(self.target.keys(), split_model_out)
+            }
+            outputs.update(predicted_dict)
+            metrics = {}
+            # metrics = {t+" error": metric_functions[t](outputs["predicted_"+t], v)
+            #            for t, v in self.target.items() if t in metric_functions}
+            metrics['loss'] = self.loss
+        return outputs, metrics

--- a/watchmal/loss/relative_huber.py
+++ b/watchmal/loss/relative_huber.py
@@ -1,0 +1,22 @@
+'''
+Relative Huber Loss
+This loss function is basically used for momentum regression.
+It uses the relative error instead of the absolute error.
+'''
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class RelativeHuberLoss(nn.Module):
+    def __init__(self, delta=1.0, eps=1e-6):
+        super().__init__()
+        self.delta = delta
+        self.eps = eps
+
+    def forward(self, input, target):
+        relative_error = (input - target) / (target + self.eps)
+        abs_error = torch.abs(relative_error)
+        quadratic = torch.minimum(abs_error, torch.tensor(self.delta, device=abs_error.device))
+        linear = abs_error - quadratic
+        loss = 0.5 * quadratic ** 2 + self.delta * linear
+        return loss.mean()

--- a/watchmal/model/SwinTransformer.py
+++ b/watchmal/model/SwinTransformer.py
@@ -1,0 +1,31 @@
+'''
+Here is a Swin Transformer model.
+'''
+import torch
+import torch.nn as nn
+import timm
+
+
+class SwinRegressor(nn.Module):
+    def __init__(
+        self,
+        model_name="swin_tiny_patch4_window7_224",
+        pretrained=False,
+        img_size=(192, 192),
+        in_chans=2,
+        num_output_channels=3,
+    ):
+        super().__init__()
+
+        self.vit = timm.create_model(
+            model_name,
+            pretrained=pretrained,
+            in_chans=in_chans,
+            num_classes=num_output_channels,
+            img_size=img_size,
+        )
+        self.output_dim = num_output_channels
+
+    def forward(self, x):
+        out = self.vit(x)
+        return out

--- a/watchmal/model/T2TViTransformer.py
+++ b/watchmal/model/T2TViTransformer.py
@@ -1,0 +1,164 @@
+'''
+Here is a T2T-ViT model (for single image input).
+'''
+import torch
+import torch.nn as nn
+from timm.layers import DropPath
+
+
+class T2T_Module(nn.Module):
+    def __init__(
+        self, img_size=(192, 192), in_chans=2, embed_dim=768, token_dims=[64, 128]
+    ):
+        super().__init__()
+        self.token_dims = token_dims
+        self.soft_split0 = nn.Conv2d(
+            in_chans, token_dims[0], kernel_size=7, stride=4, padding=3
+        )
+        self.transformer1 = TransformerBlock(
+            embed_dim=token_dims[0], num_heads=1, mlp_ratio=1.0
+        )
+        h_s1, w_s1 = img_size[0] // 4, img_size[1] // 4
+        self.soft_split1 = nn.Conv2d(
+            token_dims[0], token_dims[1], kernel_size=3, stride=2, padding=1
+        )
+        self.transformer2 = TransformerBlock(
+            embed_dim=token_dims[1], num_heads=1, mlp_ratio=1.0
+        )
+        h_s2, w_s2 = h_s1 // 2, w_s1 // 2
+        self.soft_split2 = nn.Conv2d(
+            token_dims[1], embed_dim, kernel_size=3, stride=2, padding=1
+        )
+        self.num_patches = (h_s2 // 2) * (w_s2 // 2)
+
+    def forward(self, x):
+        x = self.soft_split0(x)
+        b, c, h, w = x.shape
+        x = x.flatten(2).transpose(1, 2)
+        x = self.transformer1(x)
+        x = x.transpose(1, 2).reshape(b, c, h, w)
+        x = self.soft_split1(x)
+        b, c, h, w = x.shape
+        x = x.flatten(2).transpose(1, 2)
+        x = self.transformer2(x)
+        x = x.transpose(1, 2).reshape(b, c, h, w)
+        x = self.soft_split2(x)
+        x = x.flatten(2).transpose(1, 2)
+        return x
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, embed_dim, num_heads, mlp_ratio=4.0, dropout=0.0, drop_path=0.0):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.attn = nn.MultiheadAttention(
+            embed_dim, num_heads, dropout=dropout, batch_first=True
+        )
+        self.drop_path1 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.norm2 = nn.LayerNorm(embed_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(embed_dim, int(embed_dim * mlp_ratio)),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(int(embed_dim * mlp_ratio), embed_dim),
+            nn.Dropout(dropout),
+        )
+        self.drop_path2 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x):
+        x = x + self.drop_path1(
+            self.attn(self.norm1(x), self.norm1(x), self.norm1(x))[0]
+        )
+        x = x + self.drop_path2(self.mlp(self.norm2(x)))
+        return x
+
+
+class T2T_VisionTransformer(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        in_chans=2,
+        embed_dim=768,
+        depth=6,
+        num_heads=8,
+        mlp_ratio=4.0,
+        dropout=0.1,
+        droppath=0.01,
+        t2t_token_dims=[64, 128],
+    ):
+        super().__init__()
+
+        self.patch_embed = T2T_Module(
+            img_size=img_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            token_dims=t2t_token_dims,
+        )
+        num_patches = self.patch_embed.num_patches
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
+        self.pos_drop = nn.Dropout(p=dropout)
+
+        drop_path_rates = torch.linspace(0, droppath, depth).tolist()
+        self.encoder = nn.Sequential(
+            *[
+                TransformerBlock(
+                    embed_dim=embed_dim,
+                    num_heads=num_heads,
+                    mlp_ratio=mlp_ratio,
+                    dropout=dropout,
+                    drop_path=drop_path_rates[i],
+                )
+                for i in range(depth)
+            ]
+        )
+        self.norm = nn.LayerNorm(embed_dim)
+
+    def forward(self, x):
+        B = x.shape[0]
+        x = self.patch_embed(x)
+        cls_tokens = self.cls_token.expand(B, -1, -1)
+        x = torch.cat((cls_tokens, x), dim=1)
+        x = x + self.pos_embed
+        x = self.pos_drop(x)
+        for blk in self.encoder:
+            x = blk(x)
+        x = self.norm(x)
+        return x[:, 0]
+
+
+class T2T_ViTRegressor(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        in_chans=2,
+        embed_dim=768,
+        depth=6,
+        num_heads=8,
+        mlp_ratio=4.0,
+        dropout=0.1,
+        droppath=0.01,
+        t2t_token_dims=[64, 128],
+        num_output_channels=3,
+    ):
+        super().__init__()
+        self.vit = T2T_VisionTransformer(
+            img_size=img_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            depth=depth,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            dropout=dropout,
+            droppath=droppath,
+            t2t_token_dims=t2t_token_dims,
+        )
+
+        self.head = nn.Linear(embed_dim, num_output_channels)
+        nn.init.zeros_(self.head.bias)
+        self.output_dim = num_output_channels
+
+    def forward(self, x):
+        x = self.vit(x)
+        out = self.head(x)
+        return out

--- a/watchmal/model/T2TViTransformerDI.py
+++ b/watchmal/model/T2TViTransformerDI.py
@@ -1,0 +1,248 @@
+'''
+Here is a T2T-ViT model (for double images input).
+'''
+import torch
+import torch.nn as nn
+from timm.layers import DropPath
+
+
+class DualT2T_Module(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        in_chans_main=2,
+        in_chans_second=38,
+        embed_dim=768,
+        main_s0_channels=512,
+        k_channels_per_pair_enhanced=4,
+        second_s0_channels=128,
+        fused_s1_channels=512,
+        fused_s2_channels=128,
+    ):
+        super().__init__()
+        self.soft_split0_main = nn.Conv2d(
+            in_channels=in_chans_main,
+            out_channels=main_s0_channels,
+            kernel_size=7,
+            stride=4,
+            padding=3,
+        )
+
+        num_pairs = in_chans_second // 2
+
+        self.pair_enhancer_conv = nn.Conv2d(
+            in_channels=2,
+            out_channels=k_channels_per_pair_enhanced,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+        )
+        self.final_second_conv = nn.Conv2d(
+            in_channels=num_pairs * k_channels_per_pair_enhanced,
+            out_channels=second_s0_channels,
+            kernel_size=7,
+            stride=4,
+            padding=3,
+        )
+        self.fusion_conv = nn.Conv2d(
+            in_channels=main_s0_channels + second_s0_channels,
+            out_channels=fused_s1_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+        )
+
+        self.transformer1 = TransformerBlock(
+            embed_dim=fused_s1_channels, num_heads=1, mlp_ratio=1.0
+        )
+
+        self.soft_split1 = nn.Conv2d(
+            in_channels=fused_s1_channels,
+            out_channels=fused_s2_channels,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+
+        self.transformer2 = TransformerBlock(
+            embed_dim=fused_s2_channels, num_heads=1, mlp_ratio=1.0
+        )
+
+        self.soft_split2 = nn.Conv2d(
+            in_channels=fused_s2_channels,
+            out_channels=embed_dim,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+        self.num_patches = (img_size[0] // 16) * (img_size[1] // 16)
+
+    def forward(self, x_main, x_second):
+        B, _, H_img, W_img = x_main.shape
+        num_pairs = (
+            self.final_second_conv.in_channels // self.pair_enhancer_conv.out_channels
+        )
+        x1 = self.soft_split0_main(x_main)
+        x_second_paired = x_second.contiguous().view(B, num_pairs, 2, H_img, W_img)
+        x_second_for_enhancer = (
+            x_second_paired.permute(0, 1, 3, 4, 2)
+            .contiguous()
+            .view(-1, 2, H_img, W_img)
+        )
+        enhanced_pairs = self.pair_enhancer_conv(x_second_for_enhancer)
+        k_enh = self.pair_enhancer_conv.out_channels
+        x_combined_enhanced = enhanced_pairs.contiguous().view(
+            B, num_pairs * k_enh, H_img, W_img
+        )
+        x2 = self.final_second_conv(x_combined_enhanced)
+        x_concat = torch.cat((x1, x2), dim=1)
+        x_fused = self.fusion_conv(x_concat)
+        b, c, h, w = x_fused.shape
+        x = x_fused.flatten(2).transpose(1, 2)
+        x = self.transformer1(x)
+        x = x.transpose(1, 2).reshape(b, c, h, w)
+        x = self.soft_split1(x)
+        b, c, h, w = x.shape
+        x = x.flatten(2).transpose(1, 2)
+        x = self.transformer2(x)
+        x = x.transpose(1, 2).reshape(b, c, h, w)
+        x = self.soft_split2(x)
+        x = x.flatten(2).transpose(1, 2)
+        return x
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, embed_dim, num_heads, mlp_ratio=4.0, dropout=0.0, drop_path=0.0):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.attn = nn.MultiheadAttention(
+            embed_dim, num_heads, dropout=dropout, batch_first=True
+        )
+        self.drop_path1 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.norm2 = nn.LayerNorm(embed_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(embed_dim, int(embed_dim * mlp_ratio)),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(int(embed_dim * mlp_ratio), embed_dim),
+            nn.Dropout(dropout),
+        )
+        self.drop_path2 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x):
+        x = x + self.drop_path1(
+            self.attn(self.norm1(x), self.norm1(x), self.norm1(x))[0]
+        )
+        x = x + self.drop_path2(self.mlp(self.norm2(x)))
+        return x
+
+
+class DualT2T_VisionTransformer(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        in_chans_main=2,
+        in_chans_second=38,
+        main_s0_channels=512,
+        k_channels_per_pair_enhanced=4,
+        second_s0_channels=128,
+        fused_s1_channels=512,
+        fused_s2_channels=128,
+        embed_dim=768,
+        depth=6,
+        num_heads=8,
+        mlp_ratio=4.0,
+        dropout=0,
+        droppath=0.01,
+    ):
+        super().__init__()
+
+        self.patch_embed = DualT2T_Module(
+            img_size=img_size,
+            in_chans_main=in_chans_main,
+            in_chans_second=in_chans_second,
+            embed_dim=embed_dim,
+            main_s0_channels=main_s0_channels,
+            k_channels_per_pair_enhanced=k_channels_per_pair_enhanced,
+            second_s0_channels=second_s0_channels,
+            fused_s1_channels=fused_s1_channels,
+            fused_s2_channels=fused_s2_channels,
+        )
+        num_patches = self.patch_embed.num_patches
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
+        self.pos_drop = nn.Dropout(p=dropout)
+
+        drop_path_rates = torch.linspace(0, droppath, depth).tolist()
+        self.encoder = nn.Sequential(
+            *[
+                TransformerBlock(
+                    embed_dim=embed_dim,
+                    num_heads=num_heads,
+                    mlp_ratio=mlp_ratio,
+                    dropout=dropout,
+                    drop_path=drop_path_rates[i],
+                )
+                for i in range(depth)
+            ]
+        )
+        self.norm = nn.LayerNorm(embed_dim)
+
+    def forward(self, x_main, x_second):
+        B = x_main.shape[0]
+        x = self.patch_embed(x_main, x_second)
+        cls_tokens = self.cls_token.expand(B, -1, -1)
+        x = torch.cat((cls_tokens, x), dim=1)
+        x = x + self.pos_embed
+        x = self.pos_drop(x)
+        for blk in self.encoder:
+            x = blk(x)
+        x = self.norm(x)
+        return x[:, 0]
+
+
+class DualT2T_ViTRegressor(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        in_chans_main=2,
+        in_chans_second=38,
+        main_s0_channels=512,
+        k_channels_per_pair_enhanced=4,
+        second_s0_channels=128,
+        fused_s1_channels=512,
+        fused_s2_channels=128,
+        embed_dim=768,
+        depth=6,
+        num_heads=8,
+        mlp_ratio=4.0,
+        dropout=0,
+        droppath=0.01,
+        num_output_channels=3,
+    ):
+        super().__init__()
+        self.vit = DualT2T_VisionTransformer(
+            img_size=img_size,
+            in_chans_main=in_chans_main,
+            in_chans_second=in_chans_second,
+            main_s0_channels=main_s0_channels,
+            k_channels_per_pair_enhanced=k_channels_per_pair_enhanced,
+            second_s0_channels=second_s0_channels,
+            fused_s1_channels=fused_s1_channels,
+            fused_s2_channels=fused_s2_channels,
+            embed_dim=embed_dim,
+            depth=depth,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            dropout=dropout,
+            droppath=droppath,
+        )
+
+        self.head = nn.Linear(embed_dim, num_output_channels)
+        nn.init.zeros_(self.head.bias)
+        self.output_dim = num_output_channels
+
+    def forward(self, x_main, x_second):
+        x = self.vit(x_main, x_second)
+        out = self.head(x)
+        return out

--- a/watchmal/model/vitransformer.py
+++ b/watchmal/model/vitransformer.py
@@ -1,0 +1,169 @@
+'''
+    Here is a traditional ViT model.
+'''
+import torch
+import torch.nn as nn
+from timm.layers import DropPath
+
+
+class PatchEmbed(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        patch_size=16,
+        in_chans=2,
+        embed_dim=768,
+        use_conv_stem=False,
+    ):
+        super().__init__()
+
+        self.stem = nn.Sequential(
+            nn.Conv2d(in_chans, 64, kernel_size=7, stride=2, padding=3),
+            nn.BatchNorm2d(64),
+            nn.GELU(),
+            nn.Conv2d(64, 128, kernel_size=3, stride=2, padding=1),
+            nn.BatchNorm2d(128),
+            nn.GELU(),
+            nn.Conv2d(128, embed_dim, kernel_size=3, stride=2, padding=1),
+        )
+        self.img_size = img_size
+        self.use_conv_stem = use_conv_stem
+        self.patch_size = patch_size
+        if use_conv_stem:
+            self.grid_size = (img_size[0] // 8, img_size[1] // 8)
+        else:
+            self.grid_size = (img_size[0] // patch_size, img_size[1] // patch_size)
+            self.proj = nn.Conv2d(
+                in_chans, embed_dim, kernel_size=patch_size, stride=patch_size
+            )
+        self.num_patches = self.grid_size[0] * self.grid_size[1]
+
+    def forward(self, x):
+        if self.use_conv_stem:
+            x = self.stem(x)
+        else:
+            x = self.proj(x)
+        x = x.flatten(2).transpose(1, 2)
+        return x
+
+
+class ViTRegressor(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        patch_size=16,
+        in_chans=2,
+        embed_dim=768,
+        depth=6,
+        num_heads=8,
+        mlp_ratio=4.0,
+        dropout=0.1,
+        droppath=0.01,
+        num_output_channels=3,
+        use_conv_stem=False,
+    ):
+        super().__init__()
+
+        self.vit = VisionTransformer(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            depth=depth,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            dropout=dropout,
+            use_conv_stem=use_conv_stem,
+        )
+
+        self.head = nn.Linear(embed_dim, num_output_channels)
+        nn.init.zeros_(self.head.bias)
+        self.output_dim = num_output_channels
+
+    def forward(self, x):
+        x = self.vit(x)  # [B, embed_dim]
+        out = self.head(x)  # [B, num_output_channels]
+
+        return out
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, embed_dim, num_heads, mlp_ratio=4.0, dropout=0.0, drop_path=0.0):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.attn = nn.MultiheadAttention(
+            embed_dim, num_heads, dropout=dropout, batch_first=True
+        )
+        self.drop_path1 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.norm2 = nn.LayerNorm(embed_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(embed_dim, int(embed_dim * mlp_ratio)),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(int(embed_dim * mlp_ratio), embed_dim),
+            nn.Dropout(dropout),
+        )
+        self.drop_path2 = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x):
+        x = x + self.drop_path1(
+            self.attn(self.norm1(x), self.norm1(x), self.norm1(x))[0]
+        )
+        x = x + self.drop_path2(self.mlp(self.norm2(x)))
+        return x
+
+
+class VisionTransformer(nn.Module):
+    def __init__(
+        self,
+        img_size=(192, 192),
+        patch_size=16,
+        in_chans=2,
+        embed_dim=768,
+        depth=6,
+        num_heads=8,
+        mlp_ratio=4.0,
+        dropout=0.1,
+        droppath=0.01,
+        use_conv_stem=False,
+    ):
+        super().__init__()
+
+        self.patch_embed = PatchEmbed(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+            use_conv_stem=use_conv_stem,
+        )
+        num_patches = self.patch_embed.num_patches
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_patches + 1, embed_dim))
+        self.pos_drop = nn.Dropout(p=dropout)
+
+        drop_path_rates = torch.linspace(0, droppath, depth).tolist()
+        self.encoder = nn.Sequential(
+            *[
+                TransformerBlock(
+                    embed_dim=embed_dim,
+                    num_heads=num_heads,
+                    mlp_ratio=mlp_ratio,
+                    dropout=dropout,
+                    drop_path=drop_path_rates[i],
+                )
+                for i in range(depth)
+            ]
+        )
+        self.norm = nn.LayerNorm(embed_dim)
+
+    def forward(self, x):
+        B = x.shape[0]
+        x = self.patch_embed(x)
+        cls_tokens = self.cls_token.expand(B, -1, -1)
+        x = torch.cat((cls_tokens, x), dim=1)
+        x = x + self.pos_embed[:, : x.size(1), :]
+        x = self.pos_drop(x)
+        for blk in self.encoder:
+            x = blk(x)
+        x = self.norm(x)
+        return x[:, 0]


### PR DESCRIPTION
1. cnn_dataset.py 
    I updated some optimization method, and you can check the detail in the comment.
2. Relative error  loss function
    A better loss function uses for momentum regression.
3. ViT models
    I added four ViT models in watchmal/model.
    vitransformer.py: traditional ViT
    SwinTransformer.py: Shifted Window Transformer (here I used 'timm' library, but it's not in the apptainer.)
    T2TViTransformer.py: Token-to-token Transformer (single image) 
    T2TViTransformerDI.py: Token-to-token Transformer (double images) (This model is designed to use  hit information from both 20inch PMTs and mPMTs. Now I'm testing this)
4. AdamW and coslineLR
    The standard optimizer and scheduler use for ViT training.