### PR TITLE
Predict reconstruction on events without truth variables for loss and performance metrics

### DIFF
--- a/config/reg_test.yaml
+++ b/config/reg_test.yaml
@@ -6,11 +6,9 @@ model:
   num_output_channels: 3
 defaults:
   - data: iwcd_electron
-  - data/dataset: iwcd_cnn
   - model: resnet18
   - engine: regression
   - tasks/restore_state: restore_state
   - tasks/evaluate: test
-  - loss@tasks.evaluate.loss: huber
-  - sampler@tasks.evaluate.data_loaders.test.sampler: subset_sequential
+  - override loss@tasks.evaluate.loss: huber
   - _self_

--- a/config/resnet_test.yaml
+++ b/config/resnet_test.yaml
@@ -5,10 +5,8 @@ seed: null
 dump_path: './outputs/'
 defaults:
     - data: iwcd
-    - data/dataset: iwcd_cnn
     - model: resnet18
     - engine: classifier
     - tasks/restore_state: restore_state
     - tasks/evaluate: test
-    - sampler@tasks.evaluate.data_loaders.test.sampler: subset_sequential
     - _self_

--- a/config/tasks/evaluate/test.yaml
+++ b/config/tasks/evaluate/test.yaml
@@ -1,4 +1,5 @@
 defaults:
+  - /loss: cross_entropy
   - /data_loaders:
     - test
 report_interval: 10

--- a/config/tasks/predict/test.yaml
+++ b/config/tasks/predict/test.yaml
@@ -1,5 +1,4 @@
 defaults:
-  - /loss: cross_entropy
   - /data_loaders:
     - test
 report_interval: 10

--- a/config/tasks/predict/test.yaml
+++ b/config/tasks/predict/test.yaml
@@ -1,0 +1,4 @@
+defaults:
+  - /data_loaders:
+    - test
+report_interval: 10

--- a/config/tasks/predict/test.yaml
+++ b/config/tasks/predict/test.yaml
@@ -1,4 +1,5 @@
 defaults:
+  - /loss: cross_entropy
   - /data_loaders:
     - test
 report_interval: 10

--- a/config/tutorial_regression.yaml
+++ b/config/tutorial_regression.yaml
@@ -2,6 +2,7 @@ defaults:
     - tutorial_defaults
     - engine: regression
     - override loss@tasks.train.loss: huber
+    - override loss@tasks.evaluate.loss: huber
     - _self_
 engine:
   target_key:

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ def main(config):
         log.info(f"Using DistributedDataParallel on these devices: {devids}")
         mp.spawn(main_worker_function, nprocs=ngpus, args=(ngpus, is_distributed, config, HydraConfig.get()))
     else:
-        log.info("Only one gpu found, not using multiprocessing...")
+        log.info("Only one device found, not using multiprocessing...")
         main_worker_function(0, ngpus, is_distributed, config)
 
 

--- a/watchmal/dataset/data_utils.py
+++ b/watchmal/dataset/data_utils.py
@@ -20,7 +20,7 @@ from watchmal.dataset.samplers import DistributedSamplerWrapper
 from torch_geometric.loader import DataLoader as PyGDataLoader
 
 
-def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, seed, is_graph=False,
+def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, is_gpu, seed, is_graph=False,
                     split_path=None, split_key=None, pre_transforms=None, post_transforms=None, drop_last=False):
     """
     Creates a dataloader given the dataset and sampler configs. The dataset and sampler are instantiated using their
@@ -80,7 +80,7 @@ def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, s
         return PyGDataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=num_workers)
     else:
         return DataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=num_workers, drop_last=drop_last,
-                          persistent_workers=(num_workers > 0), pin_memory=True)
+                          persistent_workers=(num_workers > 0), pin_memory=is_gpu)
 
 
 def get_transformations(transformations, transform_names):

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -67,7 +67,7 @@ class H5CommonDataset(Dataset, ABC):
                     self.targets = {target_key: self.load_target(target_key)}
                 else:
                     self.targets = {t: self.load_target(t) for t in self.target_key}
-            except AttributeError:
+            except KeyError:
                 # truth info don't exist, can only predict but not train or evaluate
                 self.targets = None
 

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -69,7 +69,7 @@ class H5CommonDataset(Dataset, ABC):
                     self.targets = {t: self.load_target(t) for t in self.target_key}
             except KeyError:
                 # truth info don't exist, can only predict but not train or evaluate
-                self.targets = None
+                self.targets = {}
 
     def load_target(self, target_key):
         if target_key == "directions":

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -43,7 +43,7 @@ class H5CommonDataset(Dataset, ABC):
         """Dataset from the HDF5 file in `h5_path`, using memmaps for hit arrays unless `use_memmap` is set to False"""
         self.h5_path = h5_path
         with h5py.File(self.h5_path, 'r') as h5_file:
-            self.dataset_length = h5_file["labels"].shape[0]
+            self.dataset_length = h5_file["event_hits_index"].shape[0]
 
         self.label_set = None
         self.labels_key = None

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -109,7 +109,7 @@ class H5CommonDataset(Dataset, ABC):
             labels.
         """
         self.label_set = set(label_set)
-        if self.initialized and self.targets is not None:
+        if self.initialized and self.targets:
             self.unmapped_labels = self.targets[self.target_key]
             labels = np.ndarray(self.unmapped_labels.shape, dtype=np.int64)
             for i, l in enumerate(self.label_set):

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -73,9 +73,9 @@ class H5CommonDataset(Dataset, ABC):
 
     def load_target(self, target_key):
         if target_key == "directions":
-            return np.expand_dims(direction_from_angles(np.array(self.h5_file["angles"])), axis=-2)
+            return direction_from_angles(np.array(self.h5_file["angles"]))
         else:
-            return np.array(self.h5_file[target_key])
+            return np.array(self.h5_file[target_key]).squeeze()
 
     def initialize(self):
         """

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -51,9 +51,31 @@ class H5CommonDataset(Dataset, ABC):
 
         self.initialized = False
 
+        self.h5_file = None
         self.event_hits_index = None
         self.hit_pmt = None
         self.hit_time = None
+        self.target_key = None
+        self.targets = None
+        self.unmapped_labels = None
+
+    def set_target(self, target_key):
+        self.target_key = target_key
+        if self.initialized:
+            try:
+                if isinstance(self.target_key, str):
+                    self.targets = {target_key: self.load_target(target_key)}
+                else:
+                    self.targets = {t: self.load_target(t) for t in self.target_key}
+            except AttributeError:
+                # truth info don't exist, can only predict but not train or evaluate
+                self.targets = None
+
+    def load_target(self, target_key):
+        if target_key == "directions":
+            return direction_from_angles(np.array(self.h5_file["angles"]))
+        else:
+            return np.array(self.h5_file[target_key])
 
     def initialize(self):
         """
@@ -63,12 +85,6 @@ class H5CommonDataset(Dataset, ABC):
         """
         self.h5_file = h5py.File(self.h5_path, "r")
 
-        # TODO: allow configuring which array(s) to load, or do automatically from regression or classification target
-        array_list = ["labels", "positions", "angles", "energies"]
-        for a in array_list:
-            if a in self.h5_file:
-                self.__setattr__(a, np.array(self.h5_file[a]))
-
         self.event_hits_index = np.append(self.h5_file["event_hits_index"], self.h5_file["hit_pmt"].shape[0]).astype(np.int64)
         self.hit_pmt = self.load_hits("hit_pmt")
         self.hit_time = self.load_hits("hit_time")
@@ -76,11 +92,12 @@ class H5CommonDataset(Dataset, ABC):
         # Set attribute so that method won't be invoked again
         self.initialized = True
 
-        # perform label mapping now that labels have been initialised
+        # load targets and perform label mapping now the dataset has been initialised
+        self.set_target(self.target_key)
         if self.label_set is not None:
-            self.map_labels(self.label_set, self.labels_key)
+            self.map_labels(self.label_set)
 
-    def map_labels(self, label_set, labels_key="labels"):
+    def map_labels(self, label_set):
         """
         Maps the labels of the dataset into a range of integers from 0 up to N-1, where N is the number of unique labels
         in the provided label set.
@@ -90,20 +107,14 @@ class H5CommonDataset(Dataset, ABC):
         label_set: sequence of labels
             Set of all possible labels to map onto the range of integers from 0 to N-1, where N is the number of unique
             labels.
-        labels_key: string
-            Name of the key used for the labels
         """
         self.label_set = set(label_set)
-        self.labels_key = labels_key
-        if self.initialized:
-            try:
-                self.original_labels = getattr(self, labels_key)
-            except AttributeError:
-                self.original_labels = np.array(self.h5_file[labels_key])
-            labels = np.ndarray(self.original_labels.shape, dtype=int)
+        if self.initialized and self.targets is not None:
+            self.unmapped_labels = self.targets[self.target_key]
+            labels = np.ndarray(self.unmapped_labels.shape, dtype=np.int64)
             for i, l in enumerate(self.label_set):
-                labels[self.original_labels == l] = i
-            setattr(self, labels_key, labels)
+                labels[self.unmapped_labels == l] = i
+            self.targets[self.target_key] = labels
 
     def load_hits(self, h5_key):
         """Loads data from a given key in the h5 file either into numpy arrays or memmaps"""
@@ -119,19 +130,8 @@ class H5CommonDataset(Dataset, ABC):
     def __getitem__(self, item):
         if not self.initialized:
             self.initialize()
-
-        data_dict = {
-            "labels": self.labels[item].astype(np.int64),
-            "energies": self.energies[item].copy(),
-            "angles": self.angles[item].copy(),
-            "positions": self.positions[item].copy(),
-            "directions": direction_from_angles(self.angles[item]),
-            # "event_ids": self.event_ids[item],
-            # "root_files": self.root_files[item],
-            "indices": item
-        }
-        if self.labels_key is not None and self.labels_key not in data_dict:
-            data_dict[self.labels_key] = getattr(self, self.labels_key)[item].copy()
+        data_dict = {k: t[item].copy() for k, t in self.targets.items()}
+        data_dict["indices"] = item
         return data_dict
 
 

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -73,7 +73,7 @@ class H5CommonDataset(Dataset, ABC):
 
     def load_target(self, target_key):
         if target_key == "directions":
-            return direction_from_angles(np.array(self.h5_file["angles"]))
+            return np.expand_dims(direction_from_angles(np.array(self.h5_file["angles"])), axis=-2)
         else:
             return np.array(self.h5_file[target_key])
 

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -51,6 +51,10 @@ class H5CommonDataset(Dataset, ABC):
 
         self.initialized = False
 
+        self.event_hits_index = None
+        self.hit_pmt = None
+        self.hit_time = None
+
     def initialize(self):
         """
         Initialises the arrays from the HDF5 file. For DistributedDataParallel, this cannot be done when first creating
@@ -59,17 +63,13 @@ class H5CommonDataset(Dataset, ABC):
         """
         self.h5_file = h5py.File(self.h5_path, "r")
 
-        # self.event_ids  = np.array(self.h5_file["event_ids"])
-        # self.root_files = np.array(self.h5_file["root_files"])
-        self.labels = np.array(self.h5_file["labels"])
-        self.positions  = np.array(self.h5_file["positions"])
-        self.angles     = np.array(self.h5_file["angles"])
-        self.energies   = np.array(self.h5_file["energies"])
-        # if "veto" in self.h5_file.keys():
-        #     self.veto  = np.array(self.h5_file["veto"])
-        #     self.veto2 = np.array(self.h5_file["veto2"])
-        self.event_hits_index = np.append(self.h5_file["event_hits_index"], self.h5_file["hit_pmt"].shape[0]).astype(np.int64)
+        # TODO: allow configuring which array(s) to load, or do automatically from regression or classification target
+        array_list = ["labels", "positions", "angles", "energies"]
+        for a in array_list:
+            if a in self.h5_file:
+                self.__setattr__(a, np.array(self.h5_file[a]))
 
+        self.event_hits_index = np.append(self.h5_file["event_hits_index"], self.h5_file["hit_pmt"].shape[0]).astype(np.int64)
         self.hit_pmt = self.load_hits("hit_pmt")
         self.hit_time = self.load_hits("hit_time")
 

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -48,9 +48,8 @@ class ClassifierEngine(ReconstructionEngine):
             for name in loaders_config.keys():
                 self.data_loaders[name].dataset.map_labels(self.label_set)
 
-    def process_data(self, data):
+    def process_target(self, data):
         """Extract the event data and target from the input data dict"""
-        self.data = data['data'].to(self.device)
         self.target = data[self.target_key].to(self.device)
 
     def forward_pass(self):

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -27,6 +27,7 @@ class ClassifierEngine(ReconstructionEngine):
         super().__init__(target_key, model, rank, device, dump_path)
         self.softmax = torch.nn.Softmax(dim=1)
         self.label_set = label_set
+        self.target = None
 
     def configure_data_loaders(self, data_config, loaders_config, is_distributed, seed):
         """
@@ -56,8 +57,9 @@ class ClassifierEngine(ReconstructionEngine):
         """Compute softmax predictions for a batch of data."""
         self.model_out = self.model(self.data)
         softmax = self.softmax(self.model_out)
-        outputs = {self.target_key: self.target,
-                   'softmax': softmax}
+        outputs = {'softmax': softmax}
+        if self.target is not None:
+            outputs[self.target_key] = self.target
         return outputs
 
     def compute_metrics(self):

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -46,7 +46,7 @@ class ClassifierEngine(ReconstructionEngine):
         super().configure_data_loaders(data_config, loaders_config, is_distributed, seed)
         if self.label_set is not None:
             for name in loaders_config.keys():
-                self.data_loaders[name].dataset.map_labels(self.label_set, self.target_key)
+                self.data_loaders[name].dataset.map_labels(self.label_set)
 
     def process_data(self, data):
         """Extract the event data and target from the input data dict"""

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -65,7 +65,7 @@ class ClassifierEngine(ReconstructionEngine):
         """Compute loss and accuracy"""
         self.loss = self.criterion(self.model_out, self.target)
         predicted_labels = torch.argmax(self.model_out, dim=-1)
-        accuracy = (predicted_labels == self.target).mean()
+        accuracy = (predicted_labels == self.target).float().mean()
         metrics = {'loss': self.loss,
                    'accuracy': accuracy}
         return metrics

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -86,24 +86,11 @@ class ReconstructionEngine(ABC):
         self.scheduler = instantiate(scheduler_config, optimizer=self.optimizer)
 
     def configure_data_loaders(self, data_config, loaders_config, is_distributed, seed):
-        """
-        Set up data loaders from loaders hydra configs for the data config, and a list of data loader configs.
-
-        Parameters
-        ==========
-        data_config
-            Hydra config specifying dataset.
-        loaders_config
-            Hydra config specifying a list of dataloaders.
-        is_distributed : bool
-            Whether running in multiprocessing mode.
-        seed : int
-            Random seed to use to initialize dataloaders.
-        """
         is_gpu = self.device != torch.device("cpu")
         for name, loader_config in loaders_config.items():
             self.data_loaders[name] = get_data_loader(**data_config, **loader_config, is_distributed=is_distributed,
                                                       is_gpu=is_gpu, seed=seed)
+            self.data_loaders[name].dataset.set_target(self.target_key)
 
     def get_synchronized_outputs(self, output_dict):
         """

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -249,7 +249,7 @@ class ReconstructionEngine(ABC):
                 # Prepare the data for forward pass
                 self.process_data(train_data)
                 # Call forward: make a prediction & measure the average error
-                outputs, metrics = self.forward(True)
+                outputs, metrics = self.step(True,True)
                 # Convert torch tensors containing each metric into scalar
                 metrics = {k: v.item() for k, v in metrics.items()}
                 # Call backward: back-propagate error and update weights using loss = self.loss

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -40,9 +40,8 @@ class ReconstructionEngine(ABC):
         """
         # create the directory for saving the log and dump files
         self.epoch = 0
-        self.step = 0
         self.iteration = 0
-        self.best_validation_loss = 1.0e10
+        self.best_validation_loss = None
         self.dump_path = dump_path
         self.rank = rank
         self.model = model
@@ -62,8 +61,8 @@ class ReconstructionEngine(ABC):
 
         # define the placeholder attributes
         self.data = None
-        self.target = None
         self.loss = None
+        self.model_out = None
 
         # logging attributes
         self.train_log = CSVLog(self.dump_path + f"log_train_{self.rank}.csv")
@@ -161,9 +160,39 @@ class ReconstructionEngine(ABC):
         pass
 
     @abstractmethod
-    def forward(self, train=True):
+    def forward_pass(self):
         """Perform the forward pass"""
         pass
+
+    @abstractmethod
+    def compute_metrics(self):
+        """Compute the loss and other metrics"""
+        pass
+
+    def step(self, train=True, with_metrics=True):
+        """
+        Perform the forward pass and optionally compute loss and metrics on a batch of data
+
+        Parameters
+        ==========
+        train : bool
+            Whether in training mode, requiring computing gradients for backpropagation
+        with_metrics : bool
+            Whether to calculate loss and accuracy
+
+        Returns
+        =======
+        outputs : dict
+            Dictionary containing target and outputs
+        metrics : dict
+            Dictionary containing loss and other metrics
+        """
+        with torch.set_grad_enabled(train):
+            outputs = self.forward_pass()
+            if not with_metrics:
+                return outputs
+            metrics = self.compute_metrics()
+            return outputs, metrics
 
     def backward(self):
         """Backward pass using the loss computed for a mini-batch"""
@@ -195,7 +224,6 @@ class ReconstructionEngine(ABC):
         # initialize epoch and iteration counters
         self.epoch = 0
         self.iteration = 0
-        self.step = 0
         # keep track of the validation loss
         self.best_validation_loss = np.inf
         # initialize the iterator over the validation set
@@ -212,13 +240,12 @@ class ReconstructionEngine(ABC):
                 log.info(f"Epoch {self.epoch+1} starting at {datetime.now()}")
 
             train_loader = self.data_loaders["train"]
-            self.step = 0
             # update seeding for distributed samplers
             if self.is_distributed:
                 train_loader.sampler.set_epoch(self.epoch)
             # local training loop for batches in a single epoch
             steps_per_epoch = len(train_loader)
-            for self.step, train_data in enumerate(train_loader):
+            for step, train_data in enumerate(train_loader):
                 # Prepare the data for forward pass
                 self.process_data(train_data)
                 # Call forward: make a prediction & measure the average error
@@ -231,7 +258,7 @@ class ReconstructionEngine(ABC):
                 if self.scheduler is not None:
                     self.scheduler.step()
                 # update the epoch and iteration
-                self.step += 1
+                step += 1
                 self.iteration += 1
                 # get relevant attributes of result for logging
                 log_entries = {"iteration": self.iteration, "epoch": self.epoch, **metrics}
@@ -243,7 +270,9 @@ class ReconstructionEngine(ABC):
                         previous_step_time = step_time
                         step_time = datetime.now()
                         average_step_time = (step_time - previous_step_time)/val_interval
-                        print(f"Iteration {self.iteration}, Epoch {self.epoch+1}/{epochs}, Step {self.step}/{steps_per_epoch}"
+                        print(f"Iteration {self.iteration},"
+                              f" Epoch {self.epoch+1}/{epochs},"
+                              f" Step {step}/{steps_per_epoch}"
                               f" Step time {average_step_time},"
                               f" Epoch time {step_time-epoch_start_time}"
                               f" Total time {step_time-start_time}")
@@ -287,7 +316,7 @@ class ReconstructionEngine(ABC):
             # extract the event data and target from the input data dict
             self.process_data(val_data)
             # evaluate the network
-            outputs, metrics = self.forward(False)
+            outputs, metrics = self.step(False, True)
             if val_metrics is None:
                 val_metrics = metrics
             else:
@@ -314,55 +343,68 @@ class ReconstructionEngine(ABC):
         # return model to training mode
         self.model.train()
 
-    def evaluate(self, report_interval=20):
-        """Evaluate the performance of the trained model on the test set."""
-        log.info(f"Evaluating, output to directory: {self.dump_path}")
-        # Iterate over the validation set to calculate val_loss and val_acc
+    def inference(self, report_interval=20, with_metrics=True):
+        """"""
+        log.info(f"{'Evaluating' if with_metrics else 'Predicting'}, output to directory: {self.dump_path}")
+
         with torch.no_grad():
-            # Set the model to evaluation mode
             self.model.eval()
-            # evaluation loop
             start_time = datetime.now()
             step_time = start_time
             steps_per_epoch = len(self.data_loaders["test"])
-            for self.step, eval_data in enumerate(self.data_loaders["test"]):
-                # load data
-                self.process_data(eval_data)
-                # Run the forward procedure and output the result
-                outputs, metrics = self.forward(False)
-                outputs['indices'] = eval_data['indices'].to(self.device)
+            for step, data in enumerate(self.data_loaders["test"]):
+                self.process_data(data)
+
+                if with_metrics:
+                    outputs, metrics = self.step(False, True)
+                else:
+                    outputs = self.step(False, False)
+                    metrics = {}
+
+                outputs['indices'] = data['indices'].to(self.device)
+
                 # Add the local result to the final result
                 batch_size = len(outputs["indices"])
-                if self.step == 0:
-                    eval_outputs = outputs
-                    eval_metrics = {k: m * batch_size for k, m in metrics.items()}
+                if step == 0:
+                    all_outputs = outputs
+                    accumulated_metrics = {k: m * batch_size for k, m in metrics.items()}
                 else:
-                    for k in eval_outputs.keys():
-                        eval_outputs[k] = torch.cat((eval_outputs[k], outputs[k]))
-                    for k in eval_metrics.keys():
-                        eval_metrics[k] += metrics[k] * batch_size
-                # print the metrics at given intervals
-                if self.rank == 0 and self.step % report_interval == 0:
+                    for k in all_outputs.keys():
+                        all_outputs[k] = torch.cat((all_outputs[k], outputs[k]))
+                    for k in accumulated_metrics.keys():
+                        accumulated_metrics[k] += metrics[k] * batch_size
+
+                if self.rank == 0 and step % report_interval == 0:
                     previous_step_time = step_time
                     step_time = datetime.now()
                     average_step_time = (step_time - previous_step_time)/report_interval
-                    print(f"Step {self.step}/{steps_per_epoch}"
-                          f" Evaluation {', '.join(f'{k}: {v:.5g}' for k, v in metrics.items())},"
-                          f" Step time {average_step_time},"
-                          f" Total time {step_time-start_time}")
-        for k in eval_metrics.keys():
-            eval_metrics[k] /= len(eval_outputs["indices"])
+                    print_str = f"Step {step}/{steps_per_epoch}"
+                    if with_metrics:
+                        print_str += f" Evaluation {', '.join(f'{k}: {v:.5g}' for k, v in metrics.items())},"
+                    print_str += f" Step time {average_step_time}, Total time {step_time-start_time}"
+                    print(print_str)
+
+        for k in accumulated_metrics.keys():
+            accumulated_metrics[k] /= len(all_outputs["indices"])
         # Gather results from all processes
-        eval_metrics = self.get_synchronized_metrics(eval_metrics)
-        eval_outputs = self.get_synchronized_outputs(eval_outputs)
+        accumulated_metrics = self.get_synchronized_metrics(accumulated_metrics)
+        all_outputs = self.get_synchronized_outputs(all_outputs)
         if self.rank == 0:
             # Save overall evaluation results
             log.info("Saving Data...")
-            for k, v in eval_outputs.items():
+            for k, v in all_outputs.items():
                 np.save(self.dump_path + k + ".npy", v)
             # Compute overall evaluation metrics
-            for k, v in eval_metrics.items():
+            for k, v in accumulated_metrics.items():
                 log.info(f"Average evaluation {k}: {v}")
+
+    def evaluate(self, report_interval=20):
+        """Evaluate the performance of the trained model on the test set, with loss and performance metrics"""
+        self.inference(report_interval, with_metrics=True)
+
+    def predict(self, report_interval=20):
+        """Calculate predicted reconstruction on the test set, without calculating loss or performance metrics"""
+        self.inference(report_interval, with_metrics=False)
 
     def save_state(self, suffix="", name=None):
         """

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -100,8 +100,10 @@ class ReconstructionEngine(ABC):
         seed : int
             Random seed to use to initialize dataloaders.
         """
+        is_gpu = self.device != torch.device("cpu")
         for name, loader_config in loaders_config.items():
-            self.data_loaders[name] = get_data_loader(**data_config, **loader_config, is_distributed=is_distributed, seed=seed)
+            self.data_loaders[name] = get_data_loader(**data_config, **loader_config, is_distributed=is_distributed,
+                                                      is_gpu=is_gpu, seed=seed)
 
     def get_synchronized_outputs(self, output_dict):
         """

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -56,9 +56,8 @@ class RegressionEngine(ReconstructionEngine):
         self.stacked_target = None
         self.predictions = None
 
-    def process_data(self, data):
+    def process_target(self, data):
         """Extract the event data and target from the input data dict"""
-        self.data = data['data'].to(self.device)
         self.target_dict = {t: data[t].to(self.device) for t in self.target_key}
         # First time we get data, determine the target sizes
         if self.target_sizes is None:

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -52,42 +52,34 @@ class RegressionEngine(ReconstructionEngine):
             self.scale = {t: torch.tensor(target_scale_factor.get(t, 1)).to(self.device) for t in target_key}
         else:  # each target has the same scale
             self.scale = {t: torch.tensor(target_scale_factor).to(self.device) for t in target_key}
+        self.target_dict = None
+        self.stacked_target = None
+        self.predictions = None
 
     def process_data(self, data):
         """Extract the event data and target from the input data dict"""
         self.data = data['data'].to(self.device)
-        self.target = {t: data[t].to(self.device) for t in self.target_key}
+        self.target_dict = {t: data[t].to(self.device) for t in self.target_key}
         # First time we get data, determine the target sizes
         if self.target_sizes is None:
-            self.target_sizes = [v.shape[1] if len(v.shape) > 1 else 1 for v in self.target.values()]
+            self.target_sizes = [v.shape[1] if len(v.shape) > 1 else 1 for v in self.target_dict.values()]
 
-    def forward(self, train=True):
-        """
-        Compute predictions and metrics for a batch of data
+    def forward_pass(self):
+        """Compute predictions for a batch of data"""
+        # scale and stack the targets for calculating the loss
+        self.stacked_target = torch.column_stack([(v - self.offset[t]) / self.scale[t] for t, v in self.target_dict.items()])
+        # split the output for each target
+        split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
+        # evaluate the model on the data and reshape output to match the target
+        self.model_out = self.model(self.data).reshape(self.stacked_target.shape)
+        self.predictions = {"predicted_" + t: o * self.scale[t] + self.offset[t]
+                                      for t, o in zip(self.target_dict.keys(), split_model_out)}
+        return self.target_dict | self.predictions
 
-        Parameters
-        ==========
-        train : bool
-            Whether in training mode, requiring computing gradients for backpropagation
-
-        Returns
-        =======
-        dict
-            Dictionary containing loss and predicted values
-        """
-        with torch.set_grad_enabled(train):
-            # scale and stack the targets for calculating the loss
-            target = torch.column_stack([(v - self.offset[t]) / self.scale[t] for t, v in self.target.items()])
-            # evaluate the model on the data and reshape output to match the target
-            model_out = self.model(self.data).reshape(target.shape)
-            # calculate the loss
-            self.loss = self.criterion(model_out, target)
-            # split the output for each target
-            split_model_out = torch.split(model_out, self.target_sizes, dim=1)
-            # return outputs including the unscaled target dictionary plus elements for the corresponding predictions
-            outputs = self.target | {"predicted_"+t: o*self.scale[t] + self.offset[t]
-                                     for t, o in zip(self.target.keys(), split_model_out)}
-            metrics = {t+" error": metric_functions[t](outputs["predicted_"+t], v)
-                       for t, v in self.target.items() if t in metric_functions}
-            metrics['loss'] = self.loss
-        return outputs, metrics
+    def compute_metrics(self):
+        self.loss = self.criterion(self.model_out, self.stacked_target)
+        # return outputs including the unscaled target dictionary plus elements for the corresponding predictions
+        metrics = {t+" error": metric_functions[t](self.predictions["predicted_"+t], v)
+                   for t, v in self.target_dict.items() if t in metric_functions}
+        metrics['loss'] = self.loss
+        return metrics

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -91,4 +91,5 @@ class RegressionEngine(ReconstructionEngine):
 
     def restore_state(self, weight_file):
         super().restore_state(weight_file)
-        self.target_sizes = self.state_data["target_sizes"]
+        if "target_sizes" in self.state_data:
+            self.target_sizes = self.state_data["target_sizes"]

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -61,7 +61,7 @@ class RegressionEngine(ReconstructionEngine):
         self.target_dict = {t: data[t].to(self.device) for t in self.target_key}
         # First time we get data, determine the target sizes
         if self.target_sizes is None:
-            self.target_sizes = [v.shape[1] if len(v.shape) > 1 else 1 for v in self.target_dict.values()]
+            self.target_sizes = [v.shape[-1] if len(v.shape) > 1 else 1 for v in self.target_dict.values()]
 
     def forward_pass(self):
         """Compute predictions for a batch of data"""

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -72,8 +72,9 @@ class RegressionEngine(ReconstructionEngine):
         # split the output for each target
         split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
         self.predictions = {"predicted_" + t: o * self.scale[t] + self.offset[t]
-                            for t, o in zip(self.target_dict.keys(), split_model_out)}
-        # return outputs including the unscaled target dictionary plus elements for the corresponding predictions
+                            for t, o in zip(self.target_sizes.keys(), split_model_out)}
+        if self.target_dict is None:
+            return self.predictions
         return self.target_dict | self.predictions
 
     def compute_metrics(self):

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -72,7 +72,7 @@ class RegressionEngine(ReconstructionEngine):
         # split the output for each target
         split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
         self.predictions = {"predicted_" + t: o * self.scale[t] + self.offset[t]
-                            for t, o in zip(self.target_sizes.keys(), split_model_out)}
+                            for t, o in zip(self.target_key, split_model_out)}
         if self.target_dict is None:
             return self.predictions
         return self.target_dict | self.predictions

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -72,7 +72,7 @@ class RegressionEngine(ReconstructionEngine):
         # split the output for each target
         split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
         self.predictions = {"predicted_" + t: o * self.scale[t] + self.offset[t]
-                                      for t, o in zip(self.target_dict.keys(), split_model_out)}
+                            for t, o in zip(self.target_dict.keys(), split_model_out)}
         return self.target_dict | self.predictions
 
     def compute_metrics(self):

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -68,10 +68,10 @@ class RegressionEngine(ReconstructionEngine):
         """Compute predictions for a batch of data"""
         # scale and stack the targets for calculating the loss
         self.stacked_target = torch.column_stack([(v - self.offset[t]) / self.scale[t] for t, v in self.target_dict.items()])
-        # split the output for each target
-        split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
         # evaluate the model on the data and reshape output to match the target
         self.model_out = self.model(self.data).reshape(self.stacked_target.shape)
+        # split the output for each target
+        split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
         self.predictions = {"predicted_" + t: o * self.scale[t] + self.offset[t]
                                       for t, o in zip(self.target_dict.keys(), split_model_out)}
         return self.target_dict | self.predictions

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -65,10 +65,10 @@ class RegressionEngine(ReconstructionEngine):
 
     def forward_pass(self):
         """Compute predictions for a batch of data"""
+        # evaluate the model on the data
+        self.model_out = self.model(self.data)
         # scale and stack the targets for calculating the loss
         self.stacked_target = torch.column_stack([(v - self.offset[t]) / self.scale[t] for t, v in self.target_dict.items()])
-        # evaluate the model on the data and reshape output to match the target
-        self.model_out = self.model(self.data).reshape(self.stacked_target.shape)
         # split the output for each target
         split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
         self.predictions = {"predicted_" + t: o * self.scale[t] + self.offset[t]


### PR DESCRIPTION
This PR allows the reconstruction engine to run a trained model over events without calculating loss or other performance metrics like classificaton accuracy or regression precision, etc.

Currently the whole WatChMaL code assumed that the true target values were available, so the changes to allow prediction without these values was much more involved than expected requiring many changes to both the reconstruction engine (and its subclasses) and the dataset class and configuration set up. Full details are below the summary.

**Summary of changes for users**
- The new `predict` method of the reconstruction class runs inference on data using a loaded trained model, like the `evaluate` method but without requiring any truth information and does not calculate loss or other metrics
  - HDF5 data files do not need to have any truth values (no labels for classification or target values for regression) when running predictions
  - The label set is not required in the classification config
  - The target key(s) are still required in the engine config even if loading and predicting from a state from a previous run, but this requirement could be removed in future
  - For regression, the saved state for prediction **must** be from a training run after this PR, otherwise the information on the target sizes (e.g. 3D for position, etc.) is not available, since the regression network itself only returns a concatenated array of values but it needs to know how to split this into each predicted quantity
    - As a workaround to use saved model states that were created before this PR, construct a configuration that loads the old state file and runs evaluate on some data as you would have done before this PR (requiring data that has truth info), but add another `save_state` to the end of the tasks config like you would in a training run; this will save a new state file that's a copy of the old one but with the extra info so it can later be used for prediction without truth info
- The loss function needs to be defined in both the `train` task and/or the `evaluate` task
  - This is because both of these calculate loss, while other tasks don't, but a future refactor should remove this duplication so that it only needs to be defined once for the engine
  - The default loss function for evaluation (same as train) is cross-entropy loss used for classification, so **regression configs should be updated to explicitly override the evaluate loss function** (like they should already be overriing the train loss function)

**Changes to reconstruction engine**
- The `evaluate` method of the reconstruction engine is now `inference`, which can run either with or without metrics calculations so it is wrapped by two methods:
  -  `evaluate` to act the same as it did before this PR, for evaluating data using a trained model, making predictions, and calculating the loss and reconstruction quality metrics
  - `predict` to perform only the reconstruction predictions on data using a trained model
- The `forward` method is split into `forward_pass` and `compute_metrics` and replaced by the `step` method that wraps these functions, always doing the forward pass of the model but then also computing metrics only where needed
- After loading the data loaders, the target key is passed to the dataset classes so it can load the relevant target values if they exist
- `process_data` is split into `process_data` (now defined in the base class as it's the same for classification and regression) and `process_target` defined in the subclasses
- **For the `ClassifierEngine`:**
  - Only changes are to implement the above changes to the base class
- **For the `RegressionEngine`:**
  - When saving and restoring a state, the information on target sizes (e.g. 3D for position reconstruction) is included. This allows loading a pre-trained model and predicting the target without any truth information (where prevously the truth information informed what the size of the target should be)
  - Slight modification to how the targets are stacked when processing the model output, which should improve compatibility for multiple regression targets of different sizes

**Changes to the `H5Dataset` class**
- Truth arrays that may not exist (labels, energies, positions, angles) are no longer automatically read into memory under the assumption they exist in the HDF5 file
- Target arrays required for training or evaluation are now read from the H5 file, if the file contains the true target array, into memory programmatically using `set_target`, which is called by the reconstrution engine after creating the data loaders (and does nothing if the target array does not exist, so that prediction can run without truth values)
- Dataset length is now defined by the length of the `event_hits_index` array (that always should exist) rather than the `labels` array (that does not need to exist)

**Changes to configs**
- The `evaluate` task sets its own loss function by default, like the `train` task config already does
  - This is a bit annoying because it means the loss function is defined twice, once for train and once for evaluate, if doing both, so a future refactor should probably move the loss config to the engine itself rather than the tasks
- A default/example `predict/test.yaml` task config is added, which is like `evaluate/test.yaml` but allows prediction without truth values
- Some cleanup of other broken default or example configs

**Other**
- Bug fix to only pin memory if using GPU, to avoid occasional errors when using CPU only