### PR TITLE
Replace deprecated uproot.lazy with uproot.concatenate

### DIFF
--- a/analysis/read.py
+++ b/analysis/read.py
@@ -398,7 +398,7 @@ class FiTQunOutput:
         file_path: str
             Path the fiTQun output root file
         """
-        self.chain = uproot.lazy(file_path)
+        self.chain = uproot.concatenate(file_path)
 
         self.n_timewindows = self.chain['fqntwnd']
         self.timewindow = self.chain['fqtwnd']


### PR DESCRIPTION
Uproot 5 deprecates the old uproot.lazy method. This will no longer work on newer containers that have upgraded uproot version. Instead, uproot.concatenate should behave effectively the same.

The main difference is that uproot.concatenate loads the entire root files into memory immediately while uproot.lazy only read the data from disk when it was accessed.

Since the use of uproot here is to load fiTQun root files, which are typically small even for a huge number of events, it should fit in memory without trouble. Although it might slow down the initialisation of the `FitQunOutput` object because it now reads all the files content at initialisation, it should be a one-time hit in the time spent reading the files (for several million events, it took a few minutes to load) then later will be faster actually using the object's fiTQun predictions.