### PR TITLE
Add engine for training classification and multi-target regression together at the same time

### DIFF
--- a/analysis/classification.py
+++ b/analysis/classification.py
@@ -404,7 +404,11 @@ class WatChMaLClassification(ClassificationRun, WatChMaLOutput):
             conf = OmegaConf.load(self.directory + '/.hydra/config.yaml')
             self.label_map = {l: i for i, l in enumerate(set(conf.engine.label_set))}
         except OmegaConfBaseException:
-            self.label_map = None
+            try:
+                conf = OmegaConf.load(self.directory + '/.hydra/config.yaml')
+                self.label_map = {l: i for i, l in enumerate(set(conf.engine.classification_engine.label_set))}
+            except OmegaConfBaseException:
+                self.label_map = None
 
     def read_training_log_from_csv(self, directory):
         """

--- a/config/engine/joint.yaml
+++ b/config/engine/joint.yaml
@@ -1,5 +1,9 @@
 _target_: watchmal.engine.joint.JointClassificationRegression
 _recursive_: false
+defaults:
+  - /engine@classification_engine: classifier
+  - /engine@regression_engine: regression
+  - _self_
 loss_weight: 0.9
 classification_engine:
   label_set:
@@ -14,7 +18,3 @@ regression_engine:
     positions: 20
     directions: 0.05
     energies: 50
-defaults:
-  - /engine@classification_engine: classifier
-  - /engine@regression_engine: regression
-  - _self_

--- a/config/engine/joint.yaml
+++ b/config/engine/joint.yaml
@@ -11,8 +11,9 @@ regression_engine:
     - directions
     - energies
   target_scale_factor:
-    positions: 1
-    directions: 0.01
+    positions: 20
+    directions: 0.05
+    energies: 50
 defaults:
   - /engine@classification_engine: classifier
   - /engine@regression_engine: regression

--- a/config/engine/joint.yaml
+++ b/config/engine/joint.yaml
@@ -1,0 +1,19 @@
+_target_: watchmal.engine.joint.JointClassificationRegression
+_recursive_: false
+loss_weight: 0.9
+classification_engine:
+  label_set:
+    - 1
+    - 2
+regression_engine:
+  target_key:
+    - positions
+    - directions
+    - energies
+  target_scale_factor:
+    positions: 1
+    directions: 0.01
+defaults:
+  - /engine@classification_engine: classifier
+  - /engine@regression_engine: regression
+  - _self_

--- a/config/loss/joint.yaml
+++ b/config/loss/joint.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - /loss@classification: cross_entropy
+  - /loss@regression: huber

--- a/config/tutorial_joint.yaml
+++ b/config/tutorial_joint.yaml
@@ -1,0 +1,11 @@
+defaults:
+    - tutorial_defaults
+    - engine: joint
+    - override loss@tasks.train.loss: joint
+    - override loss@tasks.evaluate.loss: joint
+    - _self_
+model:
+  num_output_channels: 9
+hydra:
+  run:
+    dir: /ml_workshop/watchmal_tutorial/joint_run/

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -116,7 +116,7 @@ class H5CommonDataset(Dataset, ABC):
         self.label_set = set(label_set)
         if labels_key is not None:
             self.labels_key = labels_key
-        elif self.label_set is None:
+        elif self.labels_key is None:
             self.labels_key = self.target_key
         if self.initialized and self.targets:
             self.unmapped_labels = self.targets[self.labels_key]

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -100,7 +100,7 @@ class H5CommonDataset(Dataset, ABC):
         if self.label_set is not None:
             self.map_labels(self.label_set)
 
-    def map_labels(self, label_set):
+    def map_labels(self, label_set, labels_key=None):
         """
         Maps the labels of the dataset into a range of integers from 0 up to N-1, where N is the number of unique labels
         in the provided label set.
@@ -110,14 +110,20 @@ class H5CommonDataset(Dataset, ABC):
         label_set: sequence of labels
             Set of all possible labels to map onto the range of integers from 0 to N-1, where N is the number of unique
             labels.
+        labels_key: str
+            key in the targets dict that corresponds to the labels being mapped
         """
         self.label_set = set(label_set)
+        if labels_key is not None:
+            self.labels_key = labels_key
+        elif self.label_set is None:
+            self.labels_key = self.target_key
         if self.initialized and self.targets:
-            self.unmapped_labels = self.targets[self.target_key]
+            self.unmapped_labels = self.targets[self.labels_key]
             labels = np.ndarray(self.unmapped_labels.shape, dtype=np.int64)
             for i, l in enumerate(self.label_set):
                 labels[self.unmapped_labels == l] = i
-            self.targets[self.target_key] = labels
+            self.targets[self.labels_key] = labels
 
     def load_hits(self, h5_key):
         """Loads data from a given key in the h5 file either into numpy arrays or memmaps"""

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -5,14 +5,14 @@ from watchmal.engine.reconstruction import ReconstructionEngine
 
 class ClassifierEngine(ReconstructionEngine):
     """Engine for performing training or evaluation for a classification network."""
-    def __init__(self, target_key, model, rank, device, dump_path, label_set=None):
+    def __init__(self, target_key, model=None, rank=None, device=None, dump_path=None, label_set=None):
         """
         Parameters
         ==========
         target_key : string
             Name of the key for the target labels in the dictionary returned by the dataloader
-        model
-            `nn.module` object that contains the full network that the engine will use in training or evaluation.
+        model : nn.Module
+            Model that outputs predicted values to calculate softmax for each class
         rank : int
             The rank of process among all spawned processes (in multiprocessing mode).
         device : int
@@ -53,9 +53,8 @@ class ClassifierEngine(ReconstructionEngine):
         """Extract the event data and target from the input data dict"""
         self.target = data[self.target_key].to(self.device)
 
-    def forward_pass(self):
+    def compute_outputs(self):
         """Compute softmax predictions for a batch of data."""
-        self.model_out = self.model(self.data)
         softmax = self.softmax(self.model_out)
         outputs = {'softmax': softmax}
         if self.target is not None:

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -5,20 +5,20 @@ from watchmal.engine.reconstruction import ReconstructionEngine
 
 class ClassifierEngine(ReconstructionEngine):
     """Engine for performing training or evaluation for a classification network."""
-    def __init__(self, target_key, model=None, rank=None, device=None, dump_path=None, label_set=None):
+    def __init__(self, target_key, rank, device, dump_path, model=None, label_set=None):
         """
         Parameters
         ==========
         target_key : string
             Name of the key for the target labels in the dictionary returned by the dataloader
-        model : nn.Module
-            Model that outputs predicted values to calculate softmax for each class
         rank : int
             The rank of process among all spawned processes (in multiprocessing mode).
         device : int
             The gpu that this process is running on.
         dump_path : string
             The path to store outputs in.
+        model : nn.Module
+            Model that outputs predicted values to calculate softmax for each class
         label_set : sequence
             The set of possible labels to classify (if None, which is the default, then class labels in the data must be
             0 to N).

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -47,7 +47,7 @@ class ClassifierEngine(ReconstructionEngine):
         super().configure_data_loaders(data_config, loaders_config, is_distributed, seed)
         if self.label_set is not None:
             for name in loaders_config.keys():
-                self.data_loaders[name].dataset.map_labels(self.label_set)
+                self.data_loaders[name].dataset.map_labels(self.label_set, self.target_key)
 
     def process_target(self, data):
         """Extract the event data and target from the input data dict"""

--- a/watchmal/engine/joint.py
+++ b/watchmal/engine/joint.py
@@ -1,0 +1,120 @@
+import torch
+from torch import nn
+
+from watchmal.engine.reconstruction import ReconstructionEngine
+
+
+class JointClassificationRegression(ReconstructionEngine):
+    """Engine for performing combined regression and classification"""
+    def __init__(self, classification_engine, regression_engine, model, rank, device, dump_path, loss_weight = None):
+        """
+        Parameters
+        ==========
+        classification_engine : ClassifierEngine
+            A fully instantiated classification engine (but instantiated without its own model, rank, device, dump_path)
+        regression_engine : RegressionEngine
+            A fully instantiated regression engine (but instantiated without its own model, rank, device, dump_path)
+        model : nn.Module
+            Model that outputs concatenated [regression_outputs, classification_logits]
+        rank : int
+            The rank of process among all spawned processes (in multiprocessing mode).
+        device : int
+            The gpu that this process is running on.
+        dump_path : string
+            The path to store outputs in.
+        loss_weight : float
+            Weight L for loss calculation where the loss will be L * regression_loss + (1 - L) * classification_loss
+            If `loss_weight` is None, then use uncertainty weighting instead
+        """
+        super().__init__(
+            model=model,
+            rank=rank,
+            device=device,
+            dump_path=dump_path,
+            target_key=regression_engine.target_key + [classification_engine.target_key],
+        )
+
+        self.classification_engine = classification_engine
+        self.regression_engine = regression_engine
+        self.regression_size = None
+        self.loss_weight = loss_weight
+        if loss_weight is None:
+            self.log_vars = nn.ParameterDict({
+                "regression_log_var": nn.Parameter(torch.zeros(1)),
+                "classification_log_var": nn.Parameter(torch.zeros(1)),
+            })
+
+    def configure_loss(self, loss_config):
+        """Configure losses for both engines."""
+        self.classification_engine.configure_loss(loss_config["classification"])
+        self.regression_engine.configure_loss(loss_config["regression"])
+
+    def configure_data_loaders(self, data_config, loaders_config, is_distributed, seed):
+        """Configure data loaders shared for both engines, including label mapping for classification."""
+        super().configure_data_loaders(data_config, loaders_config, is_distributed, seed)
+        if self.classification_engine.label_set is not None:
+            for name in loaders_config.keys():
+                self.data_loaders[name].dataset.map_labels(self.classification_engine.label_set)
+
+    def process_data(self, data):
+        """Shared data handling for both sub-engines."""
+        super().process_data(data)
+        self.classification_engine.data = self.data
+        self.regression_engine.data = self.data
+
+    def process_target(self, data):
+        self.classification_engine.process_target(data)
+        self.regression_engine.process_target(data)
+
+    def compute_outputs(self):
+        """
+        Split the model output into regression and classification parts and calculate metrics of each.
+        Assumes model output shape: [batch, regression_size + num_classes] where the first part corresponds to all
+        regression predictions combined and the second to classification logits.
+        """
+        if self.regression_size is None:
+            self.regression_size = sum(self.regression_engine.target_sizes)
+        self.regression_engine.model_out = self.model_out[:, :self.regression_size]
+        self.classification_engine.model_out = self.model_out[:, self.regression_size:]
+        regression_outputs = self.regression_engine.compute_outputs()
+        classification_outputs = self.classification_engine.compute_outputs()
+        return regression_outputs | classification_outputs
+
+    def compute_metrics(self):
+        """Compute regression and classification losses with weighting"""
+        # Compute each loss separately
+        reg_metrics = self.regression_engine.compute_metrics()
+        cls_metrics = self.classification_engine.compute_metrics()
+
+        reg_loss = reg_metrics.pop("loss")
+        cls_loss = cls_metrics.pop("loss")
+
+        metrics = {
+            **reg_metrics,
+            **cls_metrics,
+            "regression_loss": reg_loss,
+            "classification_loss": cls_loss,
+        }
+
+        if self.loss_weight is None:
+            # Uncertainty-based combination
+            reg_log_var = self.log_vars["regression_log_var"]
+            cls_log_var = self.log_vars["classification_log_var"]
+            metrics.update(self.log_vars)
+            weighted_reg_loss = torch.exp(-reg_log_var) * reg_loss + reg_log_var
+            weighted_cls_loss = torch.exp(-cls_log_var) * cls_loss + cls_log_var
+            self.loss = 0.5 * (weighted_reg_loss + weighted_cls_loss)
+        else:
+            self.loss = self.loss_weight * reg_loss + (1 - self.loss_weight) * cls_loss
+
+        metrics["loss"] = self.loss
+        return metrics
+
+    def save_state(self, suffix="", name=None):
+        self.state_data["target_sizes"] = self.regression_engine.target_sizes
+        super().save_state(suffix, name)
+
+    def restore_state(self, weight_file):
+        super().restore_state(weight_file)
+        if "target_sizes" in self.state_data:
+            self.regression_engine.target_sizes = self.state_data["target_sizes"]

--- a/watchmal/engine/joint.py
+++ b/watchmal/engine/joint.py
@@ -102,9 +102,9 @@ class JointClassificationRegression(ReconstructionEngine):
             # Uncertainty-based combination
             reg_log_var = self.module.log_vars["regression_log_var"]
             cls_log_var = self.module.log_vars["classification_log_var"]
-            weighted_reg_loss = torch.exp(-reg_log_var) * reg_loss + reg_log_var
-            weighted_cls_loss = torch.exp(-cls_log_var) * cls_loss + cls_log_var
-            self.loss = 0.5 * (weighted_reg_loss + weighted_cls_loss)
+            weighted_reg_loss = 0.5*torch.exp(-reg_log_var) * reg_loss + 0.5*reg_log_var
+            weighted_cls_loss = torch.exp(-cls_log_var) * cls_loss + 0.5*cls_log_var
+            self.loss = weighted_reg_loss + weighted_cls_loss
             for k, v in self.module.log_vars.items():
                 metrics[k] = v.detach()
         else:

--- a/watchmal/engine/joint.py
+++ b/watchmal/engine/joint.py
@@ -40,9 +40,9 @@ class JointClassificationRegression(ReconstructionEngine):
         self.loss_weight = loss_weight
         if loss_weight is None:
             self.module.log_vars = nn.ParameterDict({
-                "regression_log_var": nn.Parameter(torch.zeros(1)).squeeze(),
-                "classification_log_var": nn.Parameter(torch.zeros(1)).squeeze(),
-            }).to(self.device)
+                "regression_log_var": nn.Parameter(torch.tensor(0.0)),
+                "classification_log_var": nn.Parameter(torch.tensor(0.0)),
+            })
 
 
     def configure_loss(self, loss_config):

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -325,10 +325,9 @@ class ReconstructionEngine(ABC):
             # evaluate the network
             outputs, metrics = self.step(False, True)
             if val_metrics is None:
-                val_metrics = metrics
-            else:
-                for k, v in metrics.items():
-                    val_metrics[k] += v
+                val_metrics = {k: 0 for k in metrics.keys()}
+            for k, v in metrics.items():
+                val_metrics[k] += v
         # record the validation stats to the csv
         val_metrics = {k: v/num_val_batches for k, v in val_metrics.items()}
         val_metrics = self.get_synchronized_metrics(val_metrics)

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -83,8 +83,9 @@ class ReconstructionEngine(ABC):
         self.optimizer = instantiate(optimizer_config, params=self.module.parameters())
         total_params = sum(p.numel() for p in self.module.parameters() if p.requires_grad)
         opt_params = sum(p.numel() for g in self.optimizer.param_groups for p in g['params'])
-        print(f"Total trainable parameters: {total_params}")
-        print(f"Parameters passed to optimizer: {opt_params}")
+        if self.rank == 0:
+            log.info(f"Total trainable parameters: {total_params}")
+            log.info(f"Parameters passed to optimizer: {opt_params}")
 
     def configure_scheduler(self, scheduler_config):
         """Instantiate a scheduler from a hydra config."""

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -1,5 +1,5 @@
 """
-Class for training a fully supervised classifier
+Class for training a fully supervised reconstruction network (generally classification and/or regression)
 """
 
 # generic imports
@@ -29,8 +29,8 @@ class ReconstructionEngine(ABC):
         ==========
         target_key : string
             Name of the key for the target values in the dictionary returned by the dataloader
-        model
-            `nn.module` object that contains the full network that the engine will use in training or evaluation.
+        model : nn.Module
+            The model representing the full network producing outputs for reconstruction
         rank : int
             The rank of process among all spawned processes (in multiprocessing mode).
         device : int
@@ -162,7 +162,7 @@ class ReconstructionEngine(ABC):
         pass
 
     @abstractmethod
-    def forward_pass(self):
+    def compute_outputs(self):
         """Perform the forward pass"""
         pass
 
@@ -190,7 +190,9 @@ class ReconstructionEngine(ABC):
             Dictionary containing loss and other metrics
         """
         with torch.set_grad_enabled(train):
-            outputs = self.forward_pass()
+            # evaluate the model on the data
+            self.model_out = self.model(self.data)
+            outputs = self.compute_outputs()
             if not with_metrics:
                 return outputs
             metrics = self.compute_metrics()

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -20,14 +20,15 @@ metric_functions = {
 
 class RegressionEngine(ReconstructionEngine):
     """Engine for performing training or evaluation for a regression network."""
-    def __init__(self, target_key, model, rank, device, dump_path, target_scale_offset=0, target_scale_factor=1):
+    def __init__(self, target_key, model=None, rank=None, device=None, dump_path=None,
+                 target_scale_offset=0, target_scale_factor=1):
         """
         Parameters
         ==========
         target_key : string
             Name of the key for the target values in the dictionary returned by the dataloader
-        model
-            `nn.module` object that contains the full network that the engine will use in training or evaluation.
+        model : nn.Module
+            Model that outputs predicted values for each regressed quantity
         rank : int
             The rank of process among all spawned processes (in multiprocessing mode).
         device : int
@@ -65,10 +66,8 @@ class RegressionEngine(ReconstructionEngine):
         # scale and stack the targets for calculating the loss
         self.stacked_target = torch.column_stack([(v - self.offset[t]) / self.scale[t] for t, v in self.target_dict.items()])
 
-    def forward_pass(self):
+    def compute_outputs(self):
         """Compute predictions for a batch of data"""
-        # evaluate the model on the data
-        self.model_out = self.model(self.data)
         # split the output for each target
         split_model_out = torch.split(self.model_out, self.target_sizes, dim=1)
         self.predictions = {"predicted_" + t: o * self.scale[t] + self.offset[t]

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -14,7 +14,7 @@ metric_functions = {
         lambda x, y: torch.mean(torch.arccos(torch.cos(x[:, 0])*torch.cos(y[:, 0])
                                              + torch.sin(x[:, 0])*torch.sin(y[:, 0])*torch.cos(x[:, 1]-y[:, 1]))),
     'energies':  # mean fractional error
-        lambda x, y: torch.mean((x - y) / y),
+        lambda x, y: torch.mean(torch.abs(x - y) / y),
 }
 
 

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -20,21 +20,20 @@ metric_functions = {
 
 class RegressionEngine(ReconstructionEngine):
     """Engine for performing training or evaluation for a regression network."""
-    def __init__(self, target_key, model=None, rank=None, device=None, dump_path=None,
-                 target_scale_offset=0, target_scale_factor=1):
+    def __init__(self, target_key, rank, device, dump_path, model=None, target_scale_offset=0, target_scale_factor=1):
         """
         Parameters
         ==========
         target_key : string
             Name of the key for the target values in the dictionary returned by the dataloader
-        model : nn.Module
-            Model that outputs predicted values for each regressed quantity
         rank : int
             The rank of process among all spawned processes (in multiprocessing mode).
         device : int
             The gpu that this process is running on.
         dump_path : string
             The path to store outputs in.
+        model : nn.Module
+            Model that outputs predicted values for each regressed quantity
         target_scale_offset : float or dict of float
             Offset to subtract from target values when calculating the loss, or dict of offsets for each target
         target_scale_factor : float or dict of float


### PR DESCRIPTION
This adds a new engine `JointClassificationRegression` for joint training of both classification and regression at the same time.

To configure and use this:
- The engine should be configured where the `classification_engine` and `regression_engine` config parameters should be configs for the respective sub-engines (which do not need their own datasets or models), like in the example `config/engine/joint.yaml`
- The `loss_weight` engine config parameter defines how to weight the classification and regression losses in calculating the overall loss:
  - If loss_weight is set to a numeric value: `loss = loss_weight*regression_loss + (1-loss_weight)*classification_loss`
  - If `loss_weight` is not set then dynamic "uncertainty loss weighting" is used (see [this paper](https://arxiv.org/abs/1705.07115))
- The loss config (for train and/or test tasks) should define loss functions for both classification and regression, as in the example `config/loss/joint.yaml`
- A complete example config is in `config/tutorial_joint.yaml`

Some refactoring was needed:
- In the main `ReconstructionEngine`:
  - The `forward_pass` function (which just ran the model forward then computed the outputs) is replaced with `compute_outputs` which now matches the `compute_metrics` function, while the actual forward call itself is moved to directly in the `step` function, because the joint engine needs to do the `compute_outputs` for each sub-engine from the model outputs, but only one model forward call
  - The metrics calculation during validation now accumulates from 0, rather than starting from the first batch and adding subsequent batches, to avoid modifying trainable parameters if they are used as metrics (uncertainty weighting uses the log(variance) as both a trainable parameter and a metric)
  - Reporting of the number of trainable parameters is now logged properly, and only reported once per GPU instead of duplicated for each
- `H5Dataset` and `ClassificationEngine` updated to explicitly provide the labels key when mapping labels, since the target key can now include both classification labels and regression targets
- The analysis code for reading results is updated to work with the classification sub-config of a joint run
- The model is optional for the `ClassifierEngine` and `RegressionEngine` so they can be used as sub-engines of the joint engine that has one model for both
- Fix for the `RegressionEngine` metric reporting for energy, so it uses the absolute residual rather than signed, so it reports something like the resolution rather than the bias

A couple of things not implemented that could be nice to add in future:
- The ability to train multiple classification tasks (can already train multiple regression, so should update classification to do something similar), this would also apply for when only doing classification, so isn't really related to this PR for joint classification + regression
- The ability to have different loss functions for different regression targets so the relative error Huber loss can be used for energy while usual Huber loss is used for position and direction, for example (this would also apply to multi-target regression alone, without classification, so again not part of this PR)
- Ability to modify the learning rate / optimiser separately for the uncertainty weighting log-var parameters from the main model parameters

Tested that nothing is broken for either classification or regression by running the full tutorial with this code version, and all ran fine.

Tested new functionality with the example tutorial config for joint training:
- With `loss_weight` not set, so it uses learned uncertainty weighting, training worked and gave ok results but worse than individually training classification and regression
  - Maybe requires different tuning of learning rates etc. and apparently works much better with a lower learning rate for the log-var parameters than the actual network's parameters
- With `loss_weight` fixed to 0.9, training 6 epochs of combined regression of position, direction and energy, plus classification of electron vs muon, worked and gave improved performance for every task compared to 3 epochs each of regression and classification run individually
  - Since the tutorial is just a very small dataset and short training time, it would be nice to do a proper study benchmarking how well this works in more realistic conditions