### PR TITLE
Add option to mask a set of PMT IDs

### DIFF
--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -34,6 +34,7 @@ class CNNDataset(H5Dataset):
         transforms=None,
         one_indexed=False,
         use_memmap=True,
+        mask_pmts=None,
         channel_scale_factor=None,
         channel_scale_offset=None,
         use_isHit=False,
@@ -67,6 +68,8 @@ class CNNDataset(H5Dataset):
             indexes). By default, zero-indexing is assumed.
         use_memmap: bool
             Use a memmap and load data into memory as needed (default), otherwise load entire dataset at initialisation
+        mask_pmts: list of int
+            List of PMT IDs to mask out from all data (None by default)
         ---------- The following features are used for optimization.
         channel_scale_factor: dict of float
             Dictionary with keys corresponding to channels and values contain the factors to divide that channel.
@@ -96,7 +99,7 @@ class CNNDataset(H5Dataset):
         ----------
         """
 
-        super().__init__(h5file, use_memmap)
+        super().__init__(h5file, use_memmap, mask_pmts)
 
         self.pmt_positions = np.load(pmt_positions_file)["pmt_image_positions"].astype(
             int

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -50,7 +50,7 @@ class CNNmPMTDataset(H5Dataset):
 
     def __init__(self, h5file, mpmt_positions_file, transforms=None, use_new_mpmt_convention=False, channels=None,
                  collapse_mpmt_channels=None, channel_scale_factor=None, channel_scale_offset=None, geometry_file=None,
-                 use_memmap=True):
+                 use_memmap=True, mask_pmts=None):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge data is
         formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to one mPMT
@@ -86,9 +86,11 @@ class CNNmPMTDataset(H5Dataset):
             Path to file defining the 3D geometry (PMT positions and orientations), required if using geometry channels.
         use_memmap: bool
             Use a memmap and load data into memory as needed (default), otherwise load entire dataset at initialisation
+        mask_pmts: list of int
+            List of PMT IDs to mask out from all data (None by default)
 """
 
-        super().__init__(h5file, use_memmap)
+        super().__init__(h5file, use_memmap, mask_pmts)
 
         self.use_new_mpmt_convention = use_new_mpmt_convention
         if self.use_new_mpmt_convention:

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -150,9 +150,10 @@ class H5Dataset(H5CommonDataset, ABC):
     hit_charge  (n_hits,)  float32    Charge of the digitized hit
     =============================================================
     """
-    def __init__(self, h5_path, use_memmap=True):
+    def __init__(self, h5_path, use_memmap=True, mask_pmts=None):
         H5CommonDataset.__init__(self, h5_path, use_memmap)
-        
+        self.mask_pmts = mask_pmts
+
     def initialize(self):
         """Creates a memmap for the digitized hit charge data."""
         super().initialize()
@@ -167,6 +168,11 @@ class H5Dataset(H5CommonDataset, ABC):
         self.event_hit_pmts = self.hit_pmt[start:stop]
         self.event_hit_charges = self.hit_charge[start:stop]
         self.event_hit_times = self.hit_time[start:stop]
+        if self.mask_pmts is not None:
+            mask = np.isin(self.event_hit_pmts, self.mask_pmts, invert=True)
+            self.event_hit_pmts = self.event_hit_pmts[mask]
+            self.event_hit_charges = self.event_hit_charges[mask]
+            self.event_hit_times = self.event_hit_times[mask]
 
         return data_dict
 


### PR DESCRIPTION
Adds the option to mask a set of PMTs defined by a list of PMT IDs.

This is implemented in the `H5Dataset` and propagated to both the `CNNDataset` and `CNNmPMTDataset`. Should be trivial to propagate to any other dataset classes based on `H5Dataset` if anyone wants to. (Might be nontrivial to propagate to datasets with multiple PMT types, because the PMT ID may not uniquely define a single PMT in that case.)

To use this feature, simply add the list of PMT IDs to the dataset config, e.g. like:
```
data:
  dataset:
    mask_pmts: [1, 23, 456]
```

Tested using the tutorial data, where I made a mask to remove the top seven PMTs from each of the mPMTs on the top endcap, and checked an event display that uses the `CNNmPMTDataset` class.
<img width="471" height="364" alt="image" src="https://github.com/user-attachments/assets/e4960f30-c5dd-44db-91fe-2ffda6fe9676" />
(using `mask_pmts=[686, 687, 692, 693, 694, 695, 696, 705, 706, 711, 712, 713, 714, 715, 724, 725, 730, 731, 732, 733, 734, 743, 744, 749, 750, 751, 752, 753, 762, 763, 768, 769, 770, 771, 772, 781, 782, 787, 788, 789, 790, 791, 800, 801, 806, 807, 808, 809, 810, 819, 820, 825, 826, 827, 828, 829, 838, 839, 844, 845, 846, 847, 848]`)