### PR TITLE
Fix for Joblib compatibility with pytorch dataloader workers>0

### DIFF
--- a/watchmal/dataset/data_utils.py
+++ b/watchmal/dataset/data_utils.py
@@ -80,7 +80,7 @@ def get_data_loader(dataset, batch_size, sampler, num_workers, is_distributed, i
         return PyGDataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=num_workers)
     else:
         return DataLoader(dataset, sampler=sampler, batch_size=batch_size, num_workers=num_workers, drop_last=drop_last,
-                          persistent_workers=(num_workers > 0), pin_memory=is_gpu)
+                          persistent_workers=(num_workers > 0), pin_memory=is_gpu, multiprocessing_context='fork')
 
 
 def get_transformations(transformations, transform_names):


### PR DESCRIPTION
When using Joblib to run multiprocessing jobs, e.g. multi-GPU SLURM jobs doing parallel hyperparameter sweeps, it is not compatible with pytorch dataloader workers>0 unless using "fork" instead of "spawn" multiprocessing.
Changing to "fork" should also make it more efficient with memory usage etc.
But this will break it from working on Windows. I don't know of anyone using Windows, but if there's any complaints we can find a workaround.