### PR TITLE
Fix for three-momentum and general robustness of loading target from h5 file

### DIFF
--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -79,7 +79,7 @@ class H5CommonDataset(Dataset, ABC):
             return direction_from_angles(self.load_target("angles"))
         elif target_key == "three_momenta":
             directions = direction_from_angles(self.load_target("angles"))
-            momenta = momentum_from_energy(self.load_target("energies"), self.load_target("labels"))
+            momenta = momentum_from_energy(self.load_target("energies"), self.load_target("labels"))[..., None]
             return directions*momenta
         else:
             return np.array(self.h5_file[target_key]).squeeze()

--- a/watchmal/dataset/h5_dataset.py
+++ b/watchmal/dataset/h5_dataset.py
@@ -76,10 +76,10 @@ class H5CommonDataset(Dataset, ABC):
 
     def load_target(self, target_key):
         if target_key == "directions":
-            return direction_from_angles(np.array(self.h5_file["angles"]))
+            return direction_from_angles(self.load_target("angles"))
         elif target_key == "three_momenta":
-            directions = direction_from_angles(np.array(self.h5_file["angles"]))
-            momenta = momentum_from_energy(np.array(self.h5_file["energies"]), np.array(self.h5_file["labels"]))
+            directions = direction_from_angles(self.load_target("angles"))
+            momenta = momentum_from_energy(self.load_target("energies"), self.load_target("labels"))
             return directions*momenta
         else:
             return np.array(self.h5_file[target_key]).squeeze()

--- a/watchmal/utils/math.py
+++ b/watchmal/utils/math.py
@@ -79,9 +79,9 @@ def momentum_from_energy(energy, label, particle_masses=np.array((0, 0.511, 105.
 
     Parameters
     ----------
-    energy : array_like
+    energy : array_like or scalar
         energy of particle or vector of energies of particles
-    label : array_like
+    label : array_like or int
         integer label of particle type or vector of labels of particles
     particle_masses : array_like
         array of particle masses indexed by label
@@ -91,7 +91,9 @@ def momentum_from_energy(energy, label, particle_masses=np.array((0, 0.511, 105.
     np.ndarray or scalar
         array of momentum values for each energy, or scalar if only one energy
     """
-    mass = particle_masses[label]*np.ones_like(energy)
+    energy = np.asarray(energy)
+    mass = np.asarray(particle_masses[label], dtype=energy.dtype)
+    mass = mass[(...,) + (None,) * (energy.ndim - mass.ndim)] # add axes to broadcast to energy along first axis/axes
     return np.sqrt(energy**2 - mass**2)
 
 


### PR DESCRIPTION
PR #100 fixed some situation while breaking others.

This PR hopefully works in all cases:
- In the H5 file, it should load each possible target more consistently (squeeze is applied to the "special" targets of `directions` and `three_momenta`, not only the others)
- In the H% file's three momentum calculation, energies is reshaped to match the number of dimensions of the direction array, for consistency when they're multiplied together
- In the general function for momentum from energy, it now works regardless of whether the energy and particle type label are both scalars, both arrays, or scalar label with an array of energies, and the output array always matches the shape and data type of the input energy parameter