### PR TITLE
Add options for initial convolution, including channel value offset invariance, for ResNet

### DIFF
--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -41,6 +41,7 @@ class CNNDataset(H5Dataset):
         use_orientations=False,
         geometry_file=None,
         use_invalid_value=False,
+        use_median_unhit_times=False,
         use_log_charge=False,
     ):
         """
@@ -84,6 +85,8 @@ class CNNDataset(H5Dataset):
             Location of an npz file containing the real positions and orientations info.
         use_invalid_value: bool
             Whether to set all the channel of unhit as an invalid value (like -100).
+        use_median_unhit_times: bool
+            Whether to set unhit times to the median value of the normalised hit times
         use_log_charge: bool
             Whether to logarithmically transform the charge.
         ---------- The following features are used for Visual Transformer. 
@@ -107,6 +110,7 @@ class CNNDataset(H5Dataset):
         self.use_positions = use_positions
         self.use_orientations = use_orientations
         self.use_invalid_value = use_invalid_value
+        self.use_median_unhit_times = use_median_unhit_times
         self.use_log_charge = use_log_charge
         self.data_size = np.max(self.pmt_positions, axis=0) + 1
         if use_padding:
@@ -247,9 +251,11 @@ class CNNDataset(H5Dataset):
             ) / orientations_scale
 
         if "time" in self.channel_map:
-            data[self.channel_map["time"], hit_rows, hit_cols] = (
-                hit_times - time_offset
-            ) / time_scale
+            normalised_times = (hit_times - time_offset) / time_scale
+            if self.use_median_unhit_times:
+                median_time = np.median(normalised_times)
+                data[self.channel_map["time"]] = median_time
+            data[self.channel_map["time"], hit_rows, hit_cols] = normalised_times
         if "charge" in self.channel_map:
             data[self.channel_map["charge"], hit_rows, hit_cols] = (
                 hit_charges - charge_offset

--- a/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
+++ b/watchmal/dataset/cnn_mpmt/cnn_mpmt_dataset.py
@@ -50,7 +50,7 @@ class CNNmPMTDataset(H5Dataset):
 
     def __init__(self, h5file, mpmt_positions_file, transforms=None, use_new_mpmt_convention=False, rotate_mpmts=None,
                  channels=None, collapse_mpmt_channels=None, channel_scale_factor=None, channel_scale_offset=None,
-                 geometry_file=None, use_memmap=True):
+                 use_median_unhit_times=False, geometry_file=None, use_memmap=True):
         """
         Constructs a dataset for CNN data. Event hit data is read in from the HDF5 file and the PMT charge data is
         formatted into an event-display-like image for input to a CNN. Each pixel of the image corresponds to one mPMT
@@ -84,6 +84,8 @@ class CNNmPMTDataset(H5Dataset):
         channel_scale_offset: dict[string, float]
             Dictionary with keys corresponding to channels and values contain the offsets to subtract from that channel.
             By default, no scaling is applied.
+        use_median_unhit_times: bool
+            Whether to set unhit times to the median value of the normalised hit times
         geometry_file: string
             Path to file defining the 3D geometry (PMT positions and orientations), required if using geometry channels.
         use_memmap: bool
@@ -123,6 +125,7 @@ class CNNmPMTDataset(H5Dataset):
         if channel_scale_factor is None:
             channel_scale_factor = {}
         self.scale_factor = channel_scale_factor
+        self.use_median_unhit_times = use_median_unhit_times
 
         self.image_height, self.image_width = np.max(self.mpmt_positions, axis=0) + 1
         # make some index expressions for different parts of the image, to use in transformations etc
@@ -187,7 +190,7 @@ class CNNmPMTDataset(H5Dataset):
         self.v_flip_permutation = np.array(self.v_flip_permutation)
         self.rotate_permutation = self.h_flip_permutation[self.v_flip_permutation]
 
-    def process_data(self, pmts, pmt_data):
+    def process_data(self, pmts, pmt_data, unhit_value=0):
         """Returns image-like event data array (channels, rows, columns) from arrays of PMT IDs and data at the PMTs."""
         # Ensure the data is a 2D array with first dimension being the number of pmts
         pmt_data = np.atleast_1d(pmt_data)
@@ -199,7 +202,8 @@ class CNNmPMTDataset(H5Dataset):
         rows = self.mpmt_positions[mpmts, 0]
         cols = self.mpmt_positions[mpmts, 1]
 
-        data = np.zeros((PMTS_PER_MPMT, pmt_data.shape[1], self.image_height, self.image_width), dtype=np.float32)
+        data = np.full(unhit_value, (PMTS_PER_MPMT, pmt_data.shape[1], self.image_height, self.image_width),
+                       dtype=np.float32)
         data[channels, :, rows, cols] = pmt_data
 
         # fix indexing of barrel PMTs in mPMT modules to match that of endcaps in the projection to 2D
@@ -223,7 +227,10 @@ class CNNmPMTDataset(H5Dataset):
         data = np.zeros((self.image_depth, self.image_height, self.image_width), dtype=np.float32)
         for c, r in self.channel_ranges.items():
             if c in hit_data:
-                channel_data = self.process_data(self.event_hit_pmts, hit_data[c]).squeeze()
+                unhit_values = 0
+                if c=="time" and self.use_median_unhit_times:
+                    unhit_values = np.median(hit_data[c])
+                channel_data = self.process_data(self.event_hit_pmts, hit_data[c], unhit_values).squeeze()
                 if c in self.collapse_channels:
                     channel_data = collapse_channel(channel_data)
             elif c in self.geom_data:

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -130,6 +130,17 @@ class ResNet(nn.Module):
         if shift_inv_channels is None:
             self.conv1 = nn.Conv2d(num_input_channels, 64, kernel_size=first_kernel_size, stride=first_stride, padding=0, bias=False)
         else:
+            if conv_pad_mode == "zeros":
+                pad1 = self.pad1
+                def replace_inv_channel_pad(x):
+                    values = x[:, shift_inv_channels, 0:1, 0:1]
+                    x = pad1(x)
+                    x[:, shift_inv_channels, :pad_l, :] = values
+                    x[:, shift_inv_channels, -pad_r:, :] = values
+                    x[:, shift_inv_channels, :, :pad_l] = values
+                    x[:, shift_inv_channels, :, -pad_r:] = values
+                    return x
+                self.pad1 = replace_inv_channel_pad
             self.conv1 = ShiftInvariantConv2d(shift_inv_channels, num_input_channels, 64, kernel_size=first_kernel_size, stride=first_stride, padding=0, bias=False)
         self.bn1 = self.norm(64)
         self.relu = nn.ReLU(inplace=True)

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -3,6 +3,30 @@ import torch
 import torch.nn.functional as F
 
 
+class ShiftInvariantConv2d(nn.Conv2d):
+    """
+    Conv2d whose output is invariant to a global additive shift on a subset of input channels.
+
+    Constrains weights to sum to zero over spatial dimensions and the specified
+    input channels.
+
+    Parameters
+    ----------
+    constrained_in_channels : list[int]
+        Input channel indices included in the zero-sum constraint.
+    All other parameters are identical to nn.Conv2d.
+    """
+
+    def __init__(self, constrained_in_channels, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.register_buffer("_cidx", torch.tensor(constrained_in_channels, dtype=torch.long))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        w = self.weight.clone()
+        w[:, self._cidx] -= w[:, self._cidx].mean(dim=(1, 2, 3), keepdim=True)
+        return self._conv_forward(x, self._constrained_weight, self.bias)
+
+
 def conv1x1(in_planes, out_planes, stride=1):
     """1x1 convolution"""
     return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
@@ -86,7 +110,8 @@ class Bottleneck(nn.Module):
 class ResNet(nn.Module):
 
     def __init__(self, block, layers, num_input_channels, num_output_channels, zero_init_residual=False,
-                 first_kernel_size=1, first_stride=1, conv_pad_mode='zeros', group_norm=False, n_groups=32):
+                 first_kernel_size=1, first_stride=1, shift_inv_channels=None, conv_pad_mode='zeros',
+                 group_norm=False, n_groups=32):
         if group_norm:
             class GroupNorm(nn.GroupNorm):
                 def __init__(self, num_channels):
@@ -102,7 +127,10 @@ class ResNet(nn.Module):
         pad_l = first_kernel_size // 2
         pad_r = first_kernel_size - 1 - pad_l
         self.pad1 = lambda x: F.pad(x, (pad_l, pad_r, pad_l, pad_r), mode="constant" if conv_pad_mode == "zeros" else conv_pad_mode)
-        self.conv1 = nn.Conv2d(num_input_channels, 64, kernel_size=first_kernel_size, stride=first_stride, padding=0, bias=False)
+        if shift_inv_channels is None:
+            self.conv1 = nn.Conv2d(num_input_channels, 64, kernel_size=first_kernel_size, stride=first_stride, padding=0, bias=False)
+        else:
+            self.conv1 = ShiftInvariantConv2d(shift_inv_channels, num_input_channels, 64, kernel_size=first_kernel_size, stride=first_stride, padding=0, bias=False)
         self.bn1 = self.norm(64)
         self.relu = nn.ReLU(inplace=True)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 import torch
+import torch.nn.functional as F
 
 
 def conv1x1(in_planes, out_planes, stride=1):
@@ -18,10 +19,10 @@ class BasicBlock(nn.Module):
     def __init__(self, inplanes, planes, stride=1, downsample=None, conv_pad_mode='zeros', norm=nn.BatchNorm2d):
         super(BasicBlock, self).__init__()
         
-        self.conv1 = conv3x3(inplanes, planes, stride, conv_pad_mode)
+        self.conv1 = conv3x3(inplanes, planes, 1, conv_pad_mode)
         self.bn1 = norm(planes)
         self.relu = nn.ReLU(inplace=True)
-        self.conv2 = conv3x3(planes, planes, padding_mode=conv_pad_mode)
+        self.conv2 = conv3x3(planes, planes, stride, conv_pad_mode)
         self.bn2 = norm(planes)
         self.downsample = downsample
         self.stride = stride
@@ -85,7 +86,7 @@ class Bottleneck(nn.Module):
 class ResNet(nn.Module):
 
     def __init__(self, block, layers, num_input_channels, num_output_channels, zero_init_residual=False,
-                 conv_pad_mode='zeros', group_norm=False, n_groups=32):
+                 first_kernel_size=1, first_stride=1, conv_pad_mode='zeros', group_norm=False, n_groups=32):
         if group_norm:
             class GroupNorm(nn.GroupNorm):
                 def __init__(self, num_channels):
@@ -98,7 +99,10 @@ class ResNet(nn.Module):
 
         self.inplanes = 64
 
-        self.conv1 = nn.Conv2d(num_input_channels, 64, kernel_size=1, stride=1, padding=0, bias=False)
+        pad_l = first_kernel_size // 2
+        pad_r = first_kernel_size - 1 - pad_l
+        self.pad1 = lambda x: F.pad(x, (pad_l, pad_r, pad_l, pad_r), mode="constant" if conv_pad_mode == "zeros" else conv_pad_mode)
+        self.conv1 = nn.Conv2d(num_input_channels, 64, kernel_size=first_kernel_size, stride=first_stride, padding=0, bias=False)
         self.bn1 = self.norm(64)
         self.relu = nn.ReLU(inplace=True)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
@@ -145,6 +149,7 @@ class ResNet(nn.Module):
         return nn.Sequential(*layers)
 
     def forward(self, x):
+        x = self.pad1(x)
         x = self.conv1(x)
         x = self.bn1(x)
         x = self.relu(x)

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -46,10 +46,10 @@ class BasicBlock(nn.Module):
     def __init__(self, inplanes, planes, stride=1, downsample=None, conv_pad_mode='zeros', norm=nn.BatchNorm2d):
         super(BasicBlock, self).__init__()
         
-        self.conv1 = conv3x3(inplanes, planes, 1, conv_pad_mode)
+        self.conv1 = conv3x3(inplanes, planes, stride, conv_pad_mode)
         self.bn1 = norm(planes)
         self.relu = nn.ReLU(inplace=True)
-        self.conv2 = conv3x3(planes, planes, stride, conv_pad_mode)
+        self.conv2 = conv3x3(planes, planes, padding_mode=conv_pad_mode)
         self.bn2 = norm(planes)
         self.downsample = downsample
         self.stride = stride

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -24,7 +24,7 @@ class ShiftInvariantConv2d(nn.Conv2d):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         w = self.weight.clone()
         w[:, self._cidx] -= w[:, self._cidx].mean(dim=(1, 2, 3), keepdim=True)
-        return self._conv_forward(x, self._constrained_weight, self.bias)
+        return self._conv_forward(x, w, self.bias)
 
 
 def conv1x1(in_planes, out_planes, stride=1):

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -5,15 +5,18 @@ import torch.nn.functional as F
 
 class ShiftInvariantConv2d(nn.Conv2d):
     """
-    Conv2d whose output is invariant to a global additive shift on a subset of input channels.
+    Conv2d whose output is invariant to an arbitrary constant added to a subset of input channels.
+    The constant can vary per example (event), but not per channel, and has no effect on the output of the convolution.
+    This means that the convolution only depends on relative differences between values within the receptive field for
+    those channels, and the output is independent of their absolute scale.
 
-    Constrains weights to sum to zero over spatial dimensions and the specified
-    input channels.
+    This is achieved by constraining the weights to sum to zero over spatial dimensions and the specified input channels
+    by subtracting the mean of the respective weights that multiply any input value of the specified channels.
 
     Parameters
     ----------
     constrained_in_channels : list[int]
-        Input channel indices included in the zero-sum constraint.
+        Input channel indices to be constrained to be shift invariant.
     All other parameters are identical to nn.Conv2d.
     """
 


### PR DESCRIPTION
The main feature of this PR is to introduce the capability for time-shift invariance of ResNet CNNs.

For this, the following features have been added.

ResNet model:
- Options `first_kernel_size` and `first_stride` to choose the network's first convolution's kernel size and stride (both default to the current  fixed value of 1 because that's what's typically used for mPMT data)
- Option `shift_inv_channels` to list a subset of channel indices to be made invariant an arbitrary global offset, with the intention is that this is the hit time channel(s) of the data, so that a shift in the global time offset does not affect the output of the network
- Use explicit padding function before the initial convolution, instead of the built in padding of the convolution function, to allow custom modified padding (explained below) and asymmetric padding size used when the initial convolution's kernel size is even.

CNN (and CNN mPMT) datasets:
- Add option `use_median_unhit_times` to use the median hit time to set the values of the time channel for pixels that correspond to either a location where no PMT exists or to an unhit PMT (currently and now by default these pixels' time values are set to zero, and charge values are still always set to zero for unhit or non-existent PMTs)

Time translation invariance is achieved by replacing the initial convolution with a modified convolution that constrains to zero the sum weights that multiply values from the specified channels. This constraint is enforced by subtracting the mean value of that subset of weights from each of the respective weights. This is done for all the chosen channels together, assuming that they would all be offset by the same value and we want invariance to this global offset.

There are two cases that can break this invariance if not dealt with appropriately:
- The time values of unhit PMTs or non-existent PMTs are currently set to zero by default. This would allow the network to learn the difference between a hit PMT time and an unhit/non-existent neighbouring PMT's zero time value, which equals the hit's absolute time
- When the padding mode is `"zeros"`, the initial tensor is padded with zeros before the first convolution to ensure the convolution's output tensor has the same spatial dimensions as the input, and these zero values create the same problem as mentioned above

In both cases, the solution is to use a value that shifts along with any global shifts to actual hit times. The median hit time value was chosen, since this is less likely than the mean to be skewed by hit time outliers that may occur in real data but not in training data. For unhit/non-existent PMT times, the new option in the CNN dataset enables this. For padding, in the case where zero padding is used along with shift invariance, the padding is modified to use the values of the pixel in the corner of the image at (0,0), which generally does not correspond to an actual, so the time value of a non-existent PMT is replicated for the padding. In the case of using the double-cover transformation, the (0,0) pixel does have an existing PMT that might have a genuine hit time, but when using double-cover the padding should be set to circular padding anyway, not zero padding.

The shift-invariance setup also requires that the initial convolution has a stride that is less than the kernel size (and so the kernel size must be at least 2x2) otherwise there is no overlap of the receptive field of two neighbouring locations and the network, being only able to learn differences between times within a receptive field, would be unable to learn relative differences between values between one receptive field and the neighbouring receptive field. To ensure there is overlap, the initial kernel size must be at least 2 and the initial stride less than the initial kernel size.

I tested with the HK FD setup for electron position regression, specifying that the time channel `0` should be shift invariant and the following updated config parameters:
```
dataset:
  use_median_unhit_times: true
model:
  conv_pad_mode: zeros
  first_kernel_size: 4
  first_stride: 2
  shift_inv_channels: [0]
```
The accuracy slightly exceeded the same configuration without time-shift invariance (but hyperparameters may not have been fully optimised anyway)
```T-shift invariant:  Average evaluation position error: 20.22```
```         Baseline:  Average evaluation position error: 23.16```
Testing the trained model on data that had a 1000 ns offset applied to all hit times, showed only negligible differences likely due to floating-point rounding differences:
```
Tested on unshifted times:
Step 0/1393555 Evaluation position error: 22.291, loss: 82.814
Step 10/1393555 Evaluation position error: 10.459, loss: 18.231
Step 20/1393555 Evaluation position error: 12.684, loss: 26.813
Tested on 1000 ns shifted times:
Step 0/1393555 Evaluation position error: 22.294, loss: 82.833
Step 10/1393555 Evaluation position error: 10.461, loss: 18.238
Step 20/1393555 Evaluation position error: 12.689, loss: 26.837
```

Note about mPMT data:
This setup may not work well on mPMT data, since this usually starts with a 1x1 convolution over each mPMT, which cannot overlap with a neighbouring mPMT. A time-shift invariant network in this case could learn relative hit time differences between hits within each mPMT, but not across neighbouring mPMTs. Changing the initial convolution to 2x2 with a  stride of 1 should work. If this does not learn well, another possibility to implement might be to retain the initial 1x1 convolution, add back in the mean hit time at each mPMT manually as an additional channel in the second layer, which would be a second convolution with kernel size >1 and shift invariance applied to this manually added mean hit time channel.