### PR TITLE
Add double cover for CNN Dataset

### DIFF
--- a/analysis/event_display/cnn_event_display.py
+++ b/analysis/event_display/cnn_event_display.py
@@ -5,7 +5,6 @@ import numpy as np
 from analysis.event_display.event_display import plot_event_2d, plot_event_3d
 from watchmal.dataset.cnn.cnn_dataset import CNNDataset
 from matplotlib.pyplot import cm
-import torch
 
 
 def coordinates_from_data(data):
@@ -34,7 +33,7 @@ class CNNEventDisplay(CNNDataset):
     """
     This class extends the CNNDataset class to provide event display functionality.
     """
-    def plot_data_2d(self, data, transformations=None, **kwargs):
+    def plot_data_2d(self, data, transforms=None, **kwargs):
         """
         Plots CNN data as a 2D event-display-like image.
 
@@ -42,7 +41,7 @@ class CNNEventDisplay(CNNDataset):
         ----------
         data : array_like
             Array of PMT data formatted for use in CNN, i.e. with dimensions of (x, y)
-        transformations : function or str or sequence of function or str, optional
+        transforms : function or str or sequence of function or str, optional
             Transformation function, or the name of a method of the dataset, or a sequence of functions or method names
             to apply to the data, such as those used for augmentation.
         kwargs : optional
@@ -70,19 +69,15 @@ class CNNEventDisplay(CNNDataset):
         """
         rows = self.pmt_positions[:, 0]
         columns = self.pmt_positions[:, 1]
-        data = torch.Tensor(data)
-        pmt_locations = torch.zeros_like(data, dtype=bool)  # fill a data-like array with False
-        pmt_locations[0, rows, columns] = True  # replace with True where there is an actual mPMT
-        if transformations is not None:
-            data = self.apply_transformation(transformations, data)
-            pmt_locations = self.apply_transformation(transformations, pmt_locations)
-        coordinates = coordinates_from_data(data)  # coordinates corresponding to each element of the data array
-        data_nan = np.full_like(data, np.nan)  # fill an array with nan for positions where there's no actual PMTs
-        data_nan[:, pmt_locations[0]] = data[:, pmt_locations[0]]  # replace the nans with the data where there is a PMT
-        pmt_coordinates = coordinates[pmt_locations.flatten()]  # the coordinates of where the actual mPMTs are
+        data_nan = np.full_like(data, np.nan)
+        data_nan[:, rows, columns] = data[:, rows, columns]
+        if transforms is not None:
+            data_nan = self.apply_transform(transforms, {"data": data_nan})["data"]
+        coordinates = coordinates_from_data(data_nan)  # coordinates corresponding to each element of the data array
+        pmt_coordinates = coordinates[~np.isnan(data_nan).flatten()]  # the coordinates of where the actual mPMTs are
         return plot_event_2d(data_nan.flatten(), coordinates, pmt_coordinates, **kwargs)
 
-    def plot_event_2d(self, event, transformations=None, **kwargs):
+    def plot_event_2d(self, event, transforms=None, **kwargs):
         """
         Plots an event as a 2D event-display-like image.
 
@@ -90,7 +85,7 @@ class CNNEventDisplay(CNNDataset):
         ----------
         event : int
             index of the event to plot
-        transformations : function or str or sequence of function or str, optional
+        transforms : function or str or sequence of function or str, optional
             Transformation function, or the name of a method of this class, or a sequence of functions or method names
             to apply to the event data, such as those used for augmentation.
         kwargs : optional
@@ -116,16 +111,16 @@ class CNNEventDisplay(CNNDataset):
         fig: matplotlib.figure.Figure
         ax: matplotlib.axes.Axes
         """
-        data = self[event]['data']
-        return self.plot_data_2d(data, transformations=transformations, **kwargs)
+        data = self[event]['data'].numpy()
+        return self.plot_data_2d(data, transforms=transforms, **kwargs)
 
-    def apply_transformation(self, transformation, data):
+    def apply_transform(self, transform, data):
         """
         Apply a transformation or sequence of transformations to data.
 
         Parameters
         ----------
-        transformation : function or str or sequence of function or str, optional
+        transform : function or str or sequence of function or str, optional
             Transformation function, or the name of a method of this class, or a sequence of functions or method names
             to apply to the event data, such as those used for augmentation.
         data : array_like
@@ -136,13 +131,13 @@ class CNNEventDisplay(CNNDataset):
         np.ndarray
             transformed data
         """
-        if isinstance(transformation, str):
-            transformation = getattr(self, transformation)
-        if callable(transformation):
-            return transformation(data)
+        if isinstance(transform, str):
+            transform = getattr(self, transform)
+        if callable(transform):
+            return transform(data)
         else:
-            for t in transformation:
-                data = self.apply_transformation(t, data)
+            for t in transform:
+                data = self.apply_transform(t, data)
             return data
 
     def plot_event_3d(self, event, geometry_file_path, **kwargs):

--- a/watchmal/dataset/cnn/cnn_dataset.py
+++ b/watchmal/dataset/cnn/cnn_dataset.py
@@ -118,12 +118,28 @@ class CNNDataset(H5Dataset):
         self.data_size = np.max(self.pmt_positions, axis=0) + 1
         if use_padding:
             self.data_size = padding_to_fixed_dimension
-        self.barrel_rows = [
-            row
-            for row in range(self.data_size[0])
-            if np.count_nonzero(self.pmt_positions[:, 0] == row) == self.data_size[1]
-        ]
-        self.transforms = None  # du.get_transformations(transformations, transforms)
+
+        self.image_height, self.image_width = self.data_size[0], self.data_size[1]
+        # make some index expressions for different parts of the image, to use in transformations etc
+        rows, row_counts = np.unique(self.pmt_positions[:, 0], return_counts=True)
+        cols, col_counts = np.unique(self.pmt_positions[:, 1], return_counts=True)
+        # barrel rows are those where the row appears in mpmt_positions as many times as the image width
+        barrel_rows = rows[row_counts > 0.7 * self.image_width]
+        # endcap_size is the number of rows before the first barrel row
+        self.endcap_size = np.min(barrel_rows)
+        self.barrel = np.s_[..., self.endcap_size:np.max(barrel_rows) + 1, :]
+        # endcap columns are those where the column appears more than the number of barrel rows
+        endcap_cols = cols[col_counts > len(barrel_rows)]
+        self.endcap_left = np.min(endcap_cols)
+        self.endcap_right = np.max(endcap_cols) + 1
+        self.top_endcap = np.s_[..., :self.endcap_size, self.endcap_left:self.endcap_right]
+        self.bottom_endcap = np.s_[..., -self.endcap_size:, self.endcap_left:self.endcap_right]
+
+
+        self.transforms = du.get_transformations(self, transforms)
+        if self.transforms is None:
+            self.transforms = []
+
         self.one_indexed = one_indexed
 
         if use_positions:
@@ -271,15 +287,53 @@ class CNNDataset(H5Dataset):
     def __getitem__(self, item):
         data_dict = super().__getitem__(item)
 
-        processed_data = from_numpy(
-            self.process_data(
-                self.event_hit_pmts, self.event_hit_times, self.event_hit_charges
-            )
-        )
-        processed_data = du.apply_random_transformations(
-            self.transforms, processed_data
-        )
+        processed_data = self.process_data(self.event_hit_pmts, self.event_hit_times, self.event_hit_charges)
 
+        # Apply transformations
         data_dict["data"] = processed_data
+        for t in self.transforms:
+            data_dict = t(data_dict)
+        data_dict["data"] = from_numpy(data_dict["data"].copy())
 
         return data_dict
+
+    def double_cover(self, data_dict):
+        """
+        Takes CNN input data in event-display-like format and returns the data with all parts of the detector duplicated
+        and rearranged to provide a double-cover of the image, providing two 'views' of the detector from a single image
+        with less blank space and physically meaningful cyclic boundary conditions at the edges of the image.
+
+        Since CNNDataset uses a simple PMT grid (1 PMT per pixel) instead of mPMT (19 PMTs per pixel), this version
+        is simpler - no channel permutations are needed.
+
+        The transformation looks something like the following, where PMTs on the end caps are numbered and PMTs on the
+        barrel are letters:
+        ```
+                                         CBALKJIHGFED
+                         01                01    32
+                         23                23    10
+                    ABCDEFGHIJKL   -->   DEFGHIJKLABC
+                    MNOPQRSTUVWX         PQRSTUVWXMNO
+                         45                45    76
+                         67                67    54
+                                         ONMXWVUSTRQP
+        ```
+        """
+        # Make copies of the endcaps, flipped (180° rotated), to use later
+        top_endcap_copy = np.flip(data_dict["data"][self.top_endcap], [1, 2])
+        bottom_endcap_copy = np.flip(data_dict["data"][self.bottom_endcap], [1, 2])
+        # Roll the tensor so that the first quarter is the last quarter
+        quarter_barrel_width = self.image_width // 4
+        data = np.roll(data_dict["data"], -quarter_barrel_width, 2)
+        # Paste the copied flipped endcaps a quarter barrel-width past the original endcap position
+        endcap_copy_columns = np.s_[quarter_barrel_width + self.endcap_left: quarter_barrel_width + self.endcap_right]
+        data[..., :self.endcap_size, endcap_copy_columns] = top_endcap_copy
+        data[..., -self.endcap_size:, endcap_copy_columns] = bottom_endcap_copy
+        # Rotate the bottom and top halves of barrel and concatenate to the top and bottom of the image
+        # If the endcaps are offset from the middle of the image, need to roll the flipped barrel to keep the same offset
+        offset = (self.image_width - self.endcap_right) - self.endcap_left
+        barrel_rolled = np.roll(data[self.barrel], offset, 2)
+        barrel_bottom_flipped, barrel_top_flipped = np.array_split(np.flip(barrel_rolled, [1, 2]), 2, axis=1)
+        data_dict["data"] = np.concatenate((barrel_top_flipped, data, barrel_bottom_flipped), axis=1)
+        return data_dict
+


### PR DESCRIPTION
Adds double cover transform for CNNDataset, matching how it's done in the mPMT CNN dataset but without any need for permutation of channels.

Updated the corresponding event display to handle transforms the same way.

Seems to work for HK FD, using the non-diagonal "compact" / "squashed" mapping.

<img width="262" height="532" alt="cnn_plot_geometry_x_double_cover" src="https://github.com/user-attachments/assets/5dc12bb0-2b04-4eb8-aaa1-1500fb914445" /> <img width="262" height="532" alt="cnn_plot_geometry_y_double_cover" src="https://github.com/user-attachments/assets/bc8277da-b593-4716-b093-c415c7f5db58" /> <img width="262" height="532" alt="cnn_plot_geometry_z_double_cover" src="https://github.com/user-attachments/assets/b8412a90-b951-44fc-b319-275bf39f58ec" />
