### PR TITLE
Fix cosine scheduler config

### DIFF
--- a/config/scheduler/cosinelr.yaml
+++ b/config/scheduler/cosinelr.yaml
@@ -1,4 +1,3 @@
-_target_: transformers.get_scheduler
-name: 'cosine' 
-num_warmup_steps: 50000
-num_training_steps: 1560000
+_target_: torch.optim.lr_scheduler.CosineAnnealingLR
+T_max: 780000
+eta_min: 1e-7


### PR DESCRIPTION
Commit 9ed467e7 that was accepted as part of PR #80 broke the cosine scheduler. It seems to now refer to some unknown method, specific to transformers.

So I am reverting that change so that this can be used as usual.