### PR TITLE
Performance improvements and options to reduce GPU memory use

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def main_worker_function(rank, config, hydra_config=None):
     if is_distributed:
         # Convert model batch norms to synchbatchnorm
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
-        model = DDP(model, device_ids=[device])
+        model = DDP(model, device_ids=[device], gradient_as_bucket_view=True)
 
     # Instantiate the engine
     engine = instantiate(config.engine, model=model, rank=rank, device=device, dump_path=config.dump_path)

--- a/watchmal/engine/classification.py
+++ b/watchmal/engine/classification.py
@@ -51,7 +51,7 @@ class ClassifierEngine(ReconstructionEngine):
 
     def process_target(self, data):
         """Extract the event data and target from the input data dict"""
-        self.target = data[self.target_key].to(self.device)
+        self.target = data[self.target_key].to(self.device, non_blocking=True)
 
     def forward_pass(self):
         """Compute softmax predictions for a batch of data."""

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -95,7 +95,7 @@ class ReconstructionEngine(ABC):
 
     def configure_scheduler(self, scheduler_config):
         """Instantiate a scheduler from a hydra config."""
-        
+
         self.scheduler = instantiate(scheduler_config, optimizer=self.optimizer)
 
     def configure_amp(self, amp_enabled: bool = False):
@@ -167,9 +167,9 @@ class ReconstructionEngine(ABC):
     def process_data(self, data):
         """Extract the event data from the input data dict"""
         if isinstance(data['data'], (list, tuple)):
-            self.data = type(data['data'])(d.to(self.device) for d in data['data'])
-        else: 
-            self.data = data['data'].to(self.device)
+            self.data = type(data['data'])(d.to(self.device, non_blocking=True) for d in data['data'])
+        else:
+            self.data = data['data'].to(self.device, non_blocking=True)
 
     @abstractmethod
     def process_target(self, data):

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -214,7 +214,7 @@ class ReconstructionEngine(ABC):
 
     def backward(self):
         """Backward pass using the loss computed for a mini-batch"""
-        self.optimizer.zero_grad()  # reset accumulated gradient
+        self.optimizer.zero_grad(set_to_none=True)  # free gradient tensors rather than zeroing
         self.loss.backward()  # compute new gradient
         self.optimizer.step()  # step params
 
@@ -271,7 +271,7 @@ class ReconstructionEngine(ABC):
                 outputs, metrics = self.step(True, True)
                 metrics = {k: v.item() for k, v in metrics.items()}
                 if self.use_amp and (self.scaler is not None):
-                    self.optimizer.zero_grad()
+                    self.optimizer.zero_grad(set_to_none=True)
                     previous_scale = self.scaler.get_scale()
                     self.scaler.scale(self.loss).backward()
                     self.scaler.step(self.optimizer)

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -7,6 +7,7 @@ import numpy as np
 from datetime import datetime
 from abc import ABC, abstractmethod
 import logging
+from collections import defaultdict
 
 # hydra imports
 from hydra.utils import instantiate
@@ -18,9 +19,6 @@ from torch.nn.parallel import DistributedDataParallel
 # WatChMaL imports
 from watchmal.dataset.data_utils import get_data_loader
 from watchmal.utils.logging_utils import CSVLog
-
-# AMP imports
-from torch.amp import GradScaler, autocast
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +100,7 @@ class ReconstructionEngine(ABC):
         """Configure automatic mixed precision (AMP)."""
         self.use_amp = bool(amp_enabled) and (self.device.type == "cuda")
         if self.use_amp:
-            self.scaler = GradScaler("cuda")
+            self.scaler = torch.amp.GradScaler("cuda")
         if self.rank == 0:
             log.info(f"AMP enabled: {self.use_amp}")
 
@@ -199,13 +197,13 @@ class ReconstructionEngine(ABC):
 
         Returns
         =======
-        outputs : dict
+        outputs : dict[Tensor]
             Dictionary containing target and outputs
-        metrics : dict
+        metrics : dict[Tensor]
             Dictionary containing loss and other metrics
         """
         with torch.set_grad_enabled(train):
-            with autocast(device_type=self.device.type, enabled=self.use_amp):
+            with torch.amp.autocast(device_type=self.device.type, enabled=self.use_amp):
                 outputs = self.forward_pass()
                 if not with_metrics:
                     return outputs
@@ -383,6 +381,11 @@ class ReconstructionEngine(ABC):
             start_time = datetime.now()
             step_time = start_time
             steps_per_epoch = len(self.data_loaders["test"])
+
+            all_outputs = defaultdict(list)
+            accumulated_metrics = defaultdict(int)
+            total_samples = 0
+
             for step, data in enumerate(self.data_loaders["test"]):
                 self.process_data(data)
                 if with_metrics:
@@ -392,18 +395,19 @@ class ReconstructionEngine(ABC):
                     outputs = self.step(False, False)
                     metrics = {}
 
-                outputs['indices'] = data['indices'].to(self.device)
+                outputs['indices'] = data['indices'].to(self.device, non_blocking=True)
 
                 # Add the local result to the final result
                 batch_size = len(outputs["indices"])
-                if step == 0:
-                    all_outputs = outputs
-                    accumulated_metrics = {k: m * batch_size for k, m in metrics.items()}
-                else:
-                    for k in all_outputs.keys():
-                        all_outputs[k] = torch.cat((all_outputs[k], outputs[k]))
-                    for k in accumulated_metrics.keys():
-                        accumulated_metrics[k] += metrics[k] * batch_size
+                total_samples += batch_size
+                for k in metrics:
+                    accumulated_metrics[k] += metrics[k] * batch_size
+
+                # Gather this batch to CPU on rank 0 — GPU never accumulates the full dataset
+                batch_outputs = self.get_synchronized_outputs(outputs)
+                if self.rank == 0:
+                    for k in batch_outputs:
+                        all_outputs[k].append(batch_outputs[k])
 
                 if self.rank == 0 and step % report_interval == 0:
                     previous_step_time = step_time
@@ -415,17 +419,14 @@ class ReconstructionEngine(ABC):
                     print_str += f" Step time {average_step_time}, Total time {step_time-start_time}"
                     print(print_str)
 
-        for k in accumulated_metrics.keys():
-            accumulated_metrics[k] /= len(all_outputs["indices"])
-        # Gather results from all processes
+        for k in accumulated_metrics:
+            accumulated_metrics[k] /= total_samples
         accumulated_metrics = self.get_synchronized_metrics(accumulated_metrics)
-        all_outputs = self.get_synchronized_outputs(all_outputs)
+
         if self.rank == 0:
-            # Save overall evaluation results
             log.info("Saving Data...")
             for k, v in all_outputs.items():
-                np.save(self.dump_path + k + ".npy", v)
-            # Compute overall evaluation metrics
+                np.save(self.dump_path + k + ".npy", np.concatenate(v))
             for k, v in accumulated_metrics.items():
                 log.info(f"Average evaluation {k}: {v}")
 

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -90,9 +90,10 @@ class RegressionEngine(ReconstructionEngine):
 
     def compute_metrics(self):
         self.loss = self.criterion(self.model_out, self.stacked_target)
-        # return loss and metrics for the predictions
-        metrics = {k: m for t, v in self.target_dict.items() if t in metric_functions
-                   for k, m in metric_functions[t](self.predictions["predicted_"+t], v).items()}
+        # return loss and metrics for the predictions without tracking gradients for logging-only metrics
+        with torch.no_grad():
+            metrics = {k: m for t, v in self.target_dict.items() if t in metric_functions
+                       for k, m in metric_functions[t](self.predictions["predicted_"+t].detach(), v).items()}
         metrics['loss'] = self.loss
         return metrics
 

--- a/watchmal/engine/regression.py
+++ b/watchmal/engine/regression.py
@@ -69,7 +69,7 @@ class RegressionEngine(ReconstructionEngine):
 
     def process_target(self, data):
         """Extract the event data and target from the input data dict"""
-        self.target_dict = {t: data[t].to(self.device) for t in self.target_key}
+        self.target_dict = {t: data[t].to(self.device, non_blocking=True) for t in self.target_key}
         # First time we get data, determine the target sizes
         if self.target_sizes is None:
             self.target_sizes = [v.shape[-1] if len(v.shape) > 1 else 1 for v in self.target_dict.values()]

--- a/watchmal/model/resnet.py
+++ b/watchmal/model/resnet.py
@@ -1,6 +1,7 @@
 import torch.nn as nn
 import torch
 import torch.nn.functional as F
+import torch.utils.checkpoint
 
 
 class ShiftInvariantConv2d(nn.Conv2d):
@@ -114,7 +115,7 @@ class ResNet(nn.Module):
 
     def __init__(self, block, layers, num_input_channels, num_output_channels, zero_init_residual=False,
                  first_kernel_size=1, first_stride=1, shift_inv_channels=None, conv_pad_mode='zeros',
-                 group_norm=False, n_groups=32):
+                 group_norm=False, n_groups=32, gradient_checkpointing=False):
         if group_norm:
             class GroupNorm(nn.GroupNorm):
                 def __init__(self, num_channels):
@@ -157,6 +158,8 @@ class ResNet(nn.Module):
         self.avgpool = nn.AdaptiveAvgPool2d((1,1))
         self.fc = nn.Linear(512 * block.expansion, num_output_channels)
 
+        self.use_grad_checkpointing = gradient_checkpointing
+
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
                 nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
@@ -190,16 +193,25 @@ class ResNet(nn.Module):
 
         return nn.Sequential(*layers)
 
+
+    def _run_layer(self, layer, x):
+        """Run a residual layer group, with optional gradient checkpointing."""
+        if self.use_grad_checkpointing and self.training:
+            return torch.utils.checkpoint.checkpoint_sequential(
+                layer, len(layer), x, use_reentrant=False
+            )
+        return layer(x)
+
     def forward(self, x):
         x = self.pad1(x)
         x = self.conv1(x)
         x = self.bn1(x)
         x = self.relu(x)
 
-        x = self.layer1(x)
-        x = self.layer2(x)
-        x = self.layer3(x)
-        x = self.layer4(x)
+        x = self._run_layer(self.layer1, x)
+        x = self._run_layer(self.layer2, x)
+        x = self._run_layer(self.layer3, x)
+        x = self._run_layer(self.layer4, x)
 
         x = self.avgpool(x)
         x = torch.flatten(x, 1)


### PR DESCRIPTION
Various performance improvements aimed at reducing GPU memory use and improving training and inference

- gradient checkpointing option for ResNet
  - add `gradient_checkpointing` model option (default False) to run residual layer groups through `torch.utils.checkpoint.checkpoint_sequential()` during training when enabled
  - reduces activation memory during backpropagation at the cost of increasing GPU time from re-computation in backward pass
  - Test on ResNet-152 for HK FD suggests peak memory is reduced by half, but compute time increased by ~33% for the same batch size
  - So whether this trade-off is worth it depends whether fitting larger batches is useful e.g. because larger batches compute faster overall, or because waiting for jobs to allocate on multiple large-memory GPUs is much longer than jobs allocating quicker on smaller GPUs and/or fewer GPUs
- refactor inference to avoid building full-dataset output tensors on GPU that can lead to GPU out of memory issues for large datasets
  -  previously: accumulate outputs on each GPU, performing concatenation every batch, then gather to one GPU at the end, then finally move to CPU
  - after this PR: gather GPU outputs and move to CPU batch-by-batch, then concatenate together when finally writing out
- disable autograd for regression metrics calculation
  - avoids unnecessary gradient calculations for metrics that don't need it (i.e. everything except loss)
- use `gradient_as_bucket_view=True` when wrapping the model with DDP
  - reduces gradient memory duplication by letting gradients share storage with DDP buckets
- `zero_grad(set_to_none=True)` to free gradient buffers between steps
  - avoids writing zeros into existing gradient tensors and can lower memory usage
- `.to(device, non_blocking=True)` for transfering data to GPU
  - allows better overlap of data transfer and GPU compute