### PR TITLE
Update AMP to allow choice of dtype to support modern bf16 data type

### DIFF
--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -138,11 +138,11 @@ class ReconstructionEngine(ABC):
                 if self.rank == 0:
                     tensor_list = [torch.zeros_like(tensor, device=self.device) for _ in range(self.n_gpus)]
                     torch.distributed.gather(tensor, tensor_list)
-                    global_output_dict[name] = torch.cat(tensor_list).detach().cpu().numpy()
+                    global_output_dict[name] = torch.cat(tensor_list).detach().cpu().float().numpy()
                 else:
                     torch.distributed.gather(tensor, dst=0)
             else:
-                global_output_dict[name] = tensor.detach().cpu().numpy()
+                global_output_dict[name] = tensor.detach().cpu().float().numpy()
         return global_output_dict
 
     def get_synchronized_metrics(self, metric_dict):

--- a/watchmal/engine/reconstruction.py
+++ b/watchmal/engine/reconstruction.py
@@ -53,7 +53,7 @@ class ReconstructionEngine(ABC):
         self.target_key = target_key
 
         # Automatic Mixed Precision
-        self.use_amp = False
+        self.amp_dtype = None
         self.scaler = None
 
         # Set up the parameters to save given the model type
@@ -98,13 +98,18 @@ class ReconstructionEngine(ABC):
         
         self.scheduler = instantiate(scheduler_config, optimizer=self.optimizer)
 
-    def configure_amp(self, amp_enabled: bool = False):
-        """Configure automatic mixed precision (AMP)."""
-        self.use_amp = bool(amp_enabled) and (self.device.type == "cuda")
-        if self.use_amp:
-            self.scaler = GradScaler("cuda")
+    def configure_amp(self, amp_dtype="bf16"):
+        """Configure automatic mixed precision (AMP) for given dtype (fp16 or bf16)"""
+        self.amp_dtype = None
+        self.scaler = None
+        if self.device.type == "cuda":
+            if amp_dtype == "bf16" or amp_dtype == True:
+                self.amp_dtype = torch.bfloat16
+            elif amp_dtype == "fp16":
+                self.amp_dtype = torch.float16
+                self.scaler = GradScaler("cuda")
         if self.rank == 0:
-            log.info(f"AMP enabled: {self.use_amp}")
+            log.info(f"AMP enabled: {amp_dtype}")
 
     def configure_data_loaders(self, data_config, loaders_config, is_distributed, seed):
         is_gpu = self.device != torch.device("cpu")
@@ -205,7 +210,7 @@ class ReconstructionEngine(ABC):
             Dictionary containing loss and other metrics
         """
         with torch.set_grad_enabled(train):
-            with autocast(device_type=self.device.type, enabled=self.use_amp):
+            with autocast(device_type=self.device.type, enabled=self.amp_dtype is not None, dtype=self.amp_dtype):
                 outputs = self.forward_pass()
                 if not with_metrics:
                     return outputs
@@ -213,10 +218,19 @@ class ReconstructionEngine(ABC):
                 return outputs, metrics
 
     def backward(self):
-        """Backward pass using the loss computed for a mini-batch"""
-        self.optimizer.zero_grad()  # reset accumulated gradient
-        self.loss.backward()  # compute new gradient
-        self.optimizer.step()  # step params
+        """Backward pass using the loss computed for a mini-batch, returning whether optimizer was updated"""
+        self.optimizer.zero_grad()
+        if self.amp_dtype is not None and self.scaler is not None:
+            self.scaler.scale(self.loss).backward()
+            previous_scale = self.scaler.get_scale()
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+            optimizer_was_updated = self.scaler.get_scale() >= previous_scale
+        else:
+            self.loss.backward()
+            self.optimizer.step()
+            optimizer_was_updated = True
+        return optimizer_was_updated
 
     def train(self, epochs=0, val_interval=20, num_val_batches=4, checkpointing=False, save_interval=None):
         """
@@ -270,18 +284,7 @@ class ReconstructionEngine(ABC):
                 # Call forward: make a prediction & measure the average error
                 outputs, metrics = self.step(True, True)
                 metrics = {k: v.item() for k, v in metrics.items()}
-                if self.use_amp and (self.scaler is not None):
-                    self.optimizer.zero_grad()
-                    previous_scale = self.scaler.get_scale()
-                    self.scaler.scale(self.loss).backward()
-                    self.scaler.step(self.optimizer)
-                    self.scaler.update()
-                    optimizer_was_updated = self.scaler.get_scale() >= previous_scale
-                else:
-                    # standard forward and backward pass
-                    # Call backward: back-propagate error and update weights using loss = self.loss
-                    self.backward()
-                    optimizer_was_updated = True
+                optimizer_was_updated = self.backward()
                 # run scheduler
                 if self.scheduler is not None and optimizer_was_updated:
                     self.scheduler.step()


### PR DESCRIPTION
Automatic mixed precision can be unstable when using fp16, especially for regression tasks with a large dynamic range. Modern use of AMP uses bf16 data type to allow the full dynamic range of fp32 with the memory savings of fp16. It also no longer requires using a scaler with AMP when using bf16, since the number of bits in the exponent is the same as full fp32 precision. So this PR allows choosing between the two datatypes when enabling AMP.

I have found that the old version, using AMP with fp16 often works but sometimes training produces models that overflow the fp16 precision and result in NaN outputs killing the ability to learn. So it's recommended to avoid using AMP at all if the GPU does not support bf16.

The only reason to retain the fp16 option is to support old GPUs that don't support bf16. RTX 30xx or newer, or A100s, H100s, etc., should all support bf16. Older GPUs that are no longer supported by NVIDIA CUDA do not support bf16 (V100, RTX 20xx). We might want to remove the fp16 option entirely, as it will help clean up the code and generally isn't recommended to use, but for now I left it in because it doesn't prevent anything else from working.

The `amp` config parameter should be set to either `fp16` or `bf16` to use AMP with the chosen datatype, or `None` to disable AMP.

The old `True` and `False` options for the `amp` config are accepted, with `True` meaning `bf16` and `False` disabling AMP. This potentially breaks if attempting to train on a GPU without bf16 support using an old config set to `amp: True`, because it will try to use bf16 by default. This is intentional, since AMP with fp16 is not recommended so should only be used when necessary and where its limitations are understood, while AMP should use bf16 wherever possible.